### PR TITLE
LRQA-33580 Turn on 'test.assert.warning.exceptions' by default on all functional tests

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -1562,7 +1562,7 @@
     selenium.output.dir.name=${liferay.home}/poshi
     #setx.executable=
     #test.assert.console.errors=
-    test.assert.warning.exceptions=false
+    test.assert.warning.exceptions=true
     #test.build.fix.pack.zip.url=
     #test.build.fix.pack.zip.url.previous=
     test.evaluate.logs=true


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-33580