### PR TITLE
LRQA-36859 Keep poshi runner JVM settings separate

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -557,6 +557,7 @@ information.
 		<attribute default="${basedir}" name="dir" />
 		<attribute default="true" name="failonerror" />
 		<attribute default="true" name="forcedcacheenabled" />
+		<attribute default="${env.ANT_OPTS}" name="gradleopts" />
 		<attribute default="" name="outputproperty" />
 		<attribute name="task" />
 		<element implicit="true" name="args" optional="true" />
@@ -605,7 +606,7 @@ information.
 						<arg value="-Dliferay.home=${liferay.home}" />
 						<arg value="tasks" />
 						<arg value="--all" />
-						<env key="GRADLE_OPTS" value="${env.ANT_OPTS}" />
+						<env key="GRADLE_OPTS" value="@{gradleopts}" />
 						<redirector errorproperty="@{outputproperty}.error" outputproperty="tasks.output" unless:blank="tasks.output" />
 					</exec>
 
@@ -642,7 +643,7 @@ information.
 								<arg value="-Dforced.cache.enabled=@{forcedcacheenabled}" />
 								<arg value="-Dliferay.home=${liferay.home}" />
 								<arg line="@{task}" />
-								<env key="GRADLE_OPTS" value="${env.ANT_OPTS}" />
+								<env key="GRADLE_OPTS" value="@{gradleopts}" />
 								<redirector errorproperty="@{outputproperty}.error" outputproperty="@{outputproperty}" unless:blank="@{outputproperty}" />
 							</exec>
 						</try>

--- a/build-test.xml
+++ b/build-test.xml
@@ -1470,7 +1470,20 @@ war.path=${app.server.weblogic.portal.dir}/</echo>
 					<available file="${java.jdk.home}" />
 				</and>
 				<then>
-					<gradle-execute failonerror="false" task="@{task}">
+					<if>
+						<isset property="env.ANT_OPTS" />
+						<then>
+							<propertyregex
+								input="${env.ANT_OPTS}"
+								override="true"
+								property="gradle.opts"
+								regexp="(-Xmx)(\d*\w*)"
+								replace="\12048m"
+							/>
+						</then>
+					</if>
+
+					<gradle-execute failonerror="false" gradleopts="${gradle.opts}" task="@{task}">
 						<arg value="--build-file=portal-web/build-test.gradle" />
 						<arg value="-Plocal=${test.poshi.runner.local.release}" />
 						<arg value="-PposhiRunnerExtProperties=${test.ext.properties.file}" />


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-36859

@michaelhashimoto, tested here: https://github.com/kenjiheigel/liferay-portal/pull/401. I didn't run the functional-tomcat-mysql batch though as running the smoke tests should be enough. I'll send backport pulls for this later.