### PR TITLE
LRQA-41671 Fix Liferay portal version

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -752,7 +752,7 @@
 ## Liferay Portal
 ##
 
-    liferay.portal.branch=master
+    liferay.portal.branch=7.1.x
     liferay.portal.bundle=latest
 
 ##


### PR DESCRIPTION
Hi @michaelhashimoto,
Is this okay? It's needed to fix `ant -f build-working-dir.xml` on `7.1.x-private`.

Thanks!

cc @jpince