### PR TITLE
LRCI-ENV Testing against different app servers

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -1115,88 +1115,16 @@
     test.batch.max.subgroup.size=5
 
     test.batch.names=\
-        bundle-blacklist-restart-jdk8,\
-        central-requirements-jdk8,\
-        compile-jsp-jdk8,\
-        deprecated-module-smoke-jdk8,\
-        empty-temp-dir-jdk8,\
-        #functional-bundle-tomcat-mysql57-jdk8,\
         functional-smoke-jboss71-mysql57-jdk8,\
-        functional-smoke-tomcat90-db2111-jdk8,\
-        functional-smoke-tomcat90-mariadb102-jdk8,\
-        functional-smoke-tomcat90-mysql57-jdk8,\
-        functional-smoke-tomcat90-mysql57-jdk11_open,\
-        functional-smoke-tomcat90-oracle122-jdk8,\
-        functional-smoke-tomcat90-postgresql10-jdk8,\
-        functional-smoke-tomcat90-sybase160-jdk8,\
+        functional-smoke-tomcat90-mysql57-jdk8_redhat,\
+        functional-smoke-tomcat90-mysql57-jdk8_zulu,\
+        functional-smoke-tomcat90-mysql57-jdk11_oracle,\
+        functional-smoke-tomcat90-mysql57-jdk11_zulu,\
         functional-smoke-weblogic122-mysql57-jdk8,\
         functional-smoke-websphere90-mysql57-jdk8,\
         functional-smoke-wildfly110-mariadb102-jdk8,\
-        functional-tomcat90-db2111-jdk8,\
-        functional-tomcat90-hypersonic20-jdk8,\
-        functional-tomcat90-mariadb102-jdk8,\
-        functional-tomcat90-mysql57-jdk8,\
-        functional-tomcat90-oracle122-jdk8,\
-        functional-tomcat90-postgresql10-jdk8,\
-        functional-tomcat90-sybase160-jdk8,\
         functional-upgrade-jboss71-mysql57-jdk8,\
-        functional-upgrade-tomcat90-db2111-jdk8,\
-        functional-upgrade-tomcat90-mariadb102-jdk8,\
-        functional-upgrade-tomcat90-mysql57-jdk8,\
-        functional-upgrade-tomcat90-oracle122-jdk8,\
-        functional-upgrade-tomcat90-postgresql10-jdk8,\
-        #functional-upgrade-tomcat90-sybase160-jdk8,\
-        #functional-upgrade-websphere90-mysql57-jdk8,\
-        #functional-upgrade-weblogic122-mysql57-jdk8,\
-        functional-upgrade-wildfly110-mariadb102-jdk8,\
-        jsp-runtime-compile-jdk8,\
-        integration-db2111-jdk8,\
-        integration-hypersonic20-jdk8,\
-        integration-mariadb102-jdk8,\
-        integration-mysql57-jdk8,\
-        integration-mysql57-jdk11_open,\
-        integration-oracle122-jdk8,\
-        integration-postgresql10-jdk8,\
-        integration-sybase160-jdk8,\
-        javadoc-jdk8,\
-        js-unit-jdk8,\
-        lpkg-base-jdk8,\
-        lpkg-container-jdk8,\
-        lpkg-controller-jdk8,\
-        lpkg-independence-jdk8,\
-        lpkg-override-jdk8,\
-        lpkg-persistence-jdk8,\
-        lpkg-release-jdk8,\
-        lpkg-startup-jdk8,\
-        modules-compile-jdk8,\
-        modules-functional-jdk8,\
-        modules-functional-tomcat90-mysql57-jdk8,\
-        modules-integration-db2111-jdk8,\
-        modules-integration-hypersonic20-jdk8,\
-        modules-integration-mariadb102-jdk8,\
-        modules-integration-mysql57-jdk8,\
-        modules-integration-oracle122-jdk8,\
-        modules-integration-postgresql10-jdk8,\
-        #modules-integration-sybase160-jdk8,\
-        modules-semantic-versioning-jdk8,\
-        modules-unit-jdk8,\
-        modules-unit-project-templates-jdk8,\
-        pmd-jdk8,\
-        #portal-frontend-js-lint-jdk8,\
-        #portal-license-jdk8,\
-        portal-second-startup-space-in-path-jdk8,\
-        portal-startup-space-in-path-jdk8,\
-        portal-web-jdk8,\
-        release-osgi-state-exploded-test-jdk8,\
-        release-osgi-state-lpkg-change-directory-test-jdk8,\
-        release-osgi-state-lpkg-test-jdk8,\
-        ruby-sass-compiler-jdk8,\
-        semantic-versioning-jdk8,\
-        service-builder-jdk8,\
-        source-format-jdk8,\
-        tck-jdk8,\
-        unit-jdk8,\
-        wsdd-builder-jdk8
+        functional-upgrade-wildfly110-mariadb102-jdk8
 
     test.batch.names[subrepository-validation]=\
         central-requirements-jdk8,\

--- a/test.properties
+++ b/test.properties
@@ -1122,9 +1122,7 @@
         functional-smoke-tomcat90-mysql57-jdk11_zulu,\
         functional-smoke-weblogic122-mysql57-jdk8,\
         functional-smoke-websphere90-mysql57-jdk8,\
-        functional-smoke-wildfly110-mariadb102-jdk8,\
-        functional-upgrade-jboss71-mysql57-jdk8,\
-        functional-upgrade-wildfly110-mariadb102-jdk8
+        functional-smoke-wildfly110-mariadb102-jdk8
 
     test.batch.names[subrepository-validation]=\
         central-requirements-jdk8,\

--- a/test.properties
+++ b/test.properties
@@ -1075,11 +1075,8 @@
         modules/apps/sync
 
     test.batch.dist.app.servers=\
-        jboss,\
         tomcat,\
-        weblogic,\
-        websphere,\
-        wildfly
+        weblogic
 
     test.batch.dist.source.excludes=\
         modules/**/tmp/**/*.class
@@ -1115,14 +1112,7 @@
     test.batch.max.subgroup.size=5
 
     test.batch.names=\
-        functional-smoke-jboss71-mysql57-jdk8,\
-        functional-smoke-tomcat90-mysql57-jdk8_redhat,\
-        functional-smoke-tomcat90-mysql57-jdk8_zulu,\
-        functional-smoke-tomcat90-mysql57-jdk11_oracle,\
-        functional-smoke-tomcat90-mysql57-jdk11_zulu,\
-        functional-smoke-weblogic122-mysql57-jdk8,\
-        functional-smoke-websphere90-mysql57-jdk8,\
-        functional-smoke-wildfly110-mariadb102-jdk8
+        functional-smoke-weblogic122-mysql57-jdk8
 
     test.batch.names[subrepository-validation]=\
         central-requirements-jdk8,\


### PR DESCRIPTION
* functional-smoke-jboss71-mysql57-jdk8
* functional-smoke-tomcat90-mysql57-jdk8_redhat
* functional-smoke-tomcat90-mysql57-jdk8_zulu
* functional-smoke-tomcat90-mysql57-jdk11_oracle
* functional-smoke-tomcat90-mysql57-jdk11_zulu
* functional-smoke-weblogic122-mysql57-jdk8
* functional-smoke-websphere90-mysql57-jdk8
* functional-smoke-wildfly110-mariadb102-jdk8
* functional-upgrade-jboss71-mysql57-jdk8
* functional-upgrade-wildfly110-mariadb102-jdk8