### PR TITLE
LRCI-1129 Add product teams & components as spira properties | master

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -1784,13 +1784,19 @@
     test.batch.spira.property.name[database]=Database
     test.batch.spira.property.name[java.jdk]=Java JDK
     test.batch.spira.property.name[operating.system]=Operating System
+    test.batch.spira.property.name[product.team.names]=Product Teams
+    test.batch.spira.property.name[testray.component.names]=Components
+    test.batch.spira.property.name[testray.main.component.name]=Main Component
 
     test.batch.spira.property.types[testrun]=\
         app.server,\
         browser,\
         database,\
         java.jdk,\
-        operating.system
+        operating.system,\
+        product.team.names,\
+        testray.component.names,\
+        testray.main.component.name
 
     test.batch.spira.property.value[app.server][glassfish31]=Glassfish 3.1
     test.batch.spira.property.value[app.server][jboss60]=JBoss 6.0
@@ -3843,6 +3849,7 @@
         portlet.properties.knowledge-base-portlet,\
         portlet.properties.marketplace-portlet,\
         portlet.properties.private-messaging-portlet,\
+        product.team.names,\
         project.templates,\
         remote.elasticsearch.cluster.size,\
         remote.elasticsearch.clusters.enabled,\
@@ -3874,6 +3881,11 @@
         timeout.explicit.wait,\
         web.plugins.includes,\
         web.xml.timeout
+
+    test.case.available.property.values[product.team.names]=\
+        Echo (Web Experience Management),\
+        Lima (Collaboration),\
+        Tango (Segmentation / Personalization)
 
     test.case.available.property.values[testray.main.component.name]=\
         ${testray.available.component.names}


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1129

@brianchandotcom - This pull needs to be backported to the following **7.2.x** & **7.1.x**.

I backported this where it did not cherry pick cleanly here:
* https://github.com/brianchandotcom/liferay-portal-ee/pull/29906 (7.0.x)
* https://github.com/brianchandotcom/liferay-portal-ee/pull/29907 (ee-6.2.x, ee-6.2.10, ee-6.1.x, ee-6.1.30)
