### PR TITLE
LRCI-1258 Add support for different project templates batches

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -5151,6 +5151,12 @@ log.sanitizer.enabled=false</echo>
 		<run-modules-integration-test database.type="postgresql" database.version="12.1" />
 	</target>
 
+	<target name="modules-integration-project-templates-jdk8">
+		<antcall target="modules-unit-jdk8">
+			<param name="project.templates.test.builds" value="true" />
+		</antcall>
+	</target>
+
 	<target name="modules-integration-sqlserver2017-jdk8">
 		<run-modules-integration-test database.type="sqlserver" database.version="2017" />
 	</target>
@@ -5302,6 +5308,7 @@ log.sanitizer.enabled=false</echo>
 					<arg value="-Dbuild.exclude.ant.plugin=true" />
 					<arg if:set="com.liferay.portal.search.solr7.test.unit.started" value="-Dcom.liferay.portal.search.solr7.test.unit.started=${com.liferay.portal.search.solr7.test.unit.started}" />
 					<arg value="-Djunit.code.coverage=${test.batch.code.coverage}" />
+					<arg if:set="project.templates.test.builds" value="-Dproject.templates.test.builds=${project.templates.test.builds}" />
 					<arg value="-Dtest.class.group.index=${axis.variable}" />
 				</gradle-execute>
 			</test-action>
@@ -5332,7 +5339,9 @@ log.sanitizer.enabled=false</echo>
 	</target>
 
 	<target name="modules-unit-project-templates-jdk8">
-		<antcall target="modules-unit-jdk8" />
+		<antcall target="modules-unit-jdk8">
+			<param name="project.templates.test.builds" value="false" />
+		</antcall>
 	</target>
 
 	<target name="oracle-service-start">

--- a/test.properties
+++ b/test.properties
@@ -1061,9 +1061,10 @@
     test.batch.axis.max.size[modules-compile-jdk8]=500
     test.batch.axis.max.size[modules-integration-*-jdk8]=35
     test.batch.axis.max.size[modules-integration-*-jdk11_open]=35
+    test.batch.axis.max.size[modules-integration-project-templates-jdk8]=25
     test.batch.axis.max.size[modules-semantic-versioning-jdk8]=30
     test.batch.axis.max.size[modules-unit-jdk8]=250
-    test.batch.axis.max.size[modules-unit-project-templates-jdk8]=250
+    test.batch.axis.max.size[modules-unit-project-templates-jdk8]=25
     test.batch.axis.max.size[semantic-versioning-jdk8]=50
     test.batch.axis.max.size[tck-jdk8]=50
     test.batch.axis.max.size[unit-jdk8]=5000
@@ -1098,6 +1099,7 @@
         **/test/unit/**/*Test.java
 
     test.batch.class.names.includes[junit-test-csv-report-jdk8]=${test.batch.class.names.includes}
+    test.batch.class.names.includes[modules-integration-project-templates-jdk8]=**/project-templates/**/src/test/**/*Test.java
     test.batch.class.names.includes[modules-integration-*-jdk8]=**/src/testIntegration/**/*Test.java
 
     test.batch.class.names.includes[modules-integration-*-jdk8_stable]=\
@@ -2036,6 +2038,7 @@
         modules-integration-mysql57-jdk11_open,\
         modules-integration-postgresql10-jdk8,\
         modules-integration-postgresql121-jdk8,\
+        modules-integration-project-templates-jdk8,\
         modules-semantic-versioning-jdk8,\
         modules-unit-jdk8,\
         modules-unit-project-templates-jdk8,\
@@ -3138,6 +3141,7 @@
     test.batch.dist.app.servers[project-templates]=tomcat
 
     test.batch.names[project-templates]=\
+        modules-integration-project-templates-jdk8,\
         modules-unit-project-templates-jdk8
 
     #
@@ -3196,6 +3200,7 @@
         modules-integration-mysql57-jdk8,\
         modules-semantic-versioning-jdk8,\
         modules-unit-jdk8,\
+        modules-unit-project-templates-jdk8,\
         pmd-jdk8,\
         semantic-versioning-jdk8,\
         service-builder-jdk8
@@ -3560,6 +3565,7 @@
         functional-upgrade-tomcat90-mysql57-jdk8_stable,\
         modules-integration-mysql57-jdk8_stable,\
         modules-unit-jdk8_stable,\
+        modules-unit-project-templates-jdk8,\
         pmd-jdk8,\
         unit-jdk8_stable
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1258

@lawrence-lee @jpince @vicnate5 - Here's the pull to add project template batches back into *ci:test:stable* & *ci:test:relevant*.

It should be running much faster now.

Thanks!