### PR TITLE
LRCI-1300 Add upstream-dxp test suite to eventually replace test-portal-upstream | master

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -3774,6 +3774,63 @@
         modules-unit-jdk8
 
     #
+    # Upstream DXP
+    #
+
+    test.batch.names[upstream-dxp]=\
+        database-upgrade-client-jdk8,\
+        functional-tomcat90-db2111-jdk8,\
+        functional-tomcat90-hypersonic20-jdk8,\
+        functional-tomcat90-mariadb102-jdk8,\
+        functional-tomcat90-mysql57-jdk8,\
+        functional-tomcat90-oracle122-jdk8,\
+        functional-tomcat90-postgresql10-jdk8,\
+        functional-tomcat90-sybase160-jdk8
+
+    test.batch.names.smoke[upstream-dxp]=\
+        functional-smoke-tomcat90-mysql57-jdk8
+
+    test.batch.run.property.query[functional-smoke-tomcat90-mysql57-jdk8][upstream-dxp]=\
+        (app.server.types == null OR app.server.types ~ tomcat) AND \
+        (database.types == null OR database.types ~ mysql) AND \
+        (portal.smoke == true)
+
+    test.batch.run.property.query[functional-tomcat90-db2111-jdk8][upstream-dxp]=\
+        (app.server.types == null OR app.server.types ~ tomcat) AND \
+        (database.types ~ db2) AND \
+        (portal.upstream == true OR portal.upstream == quarantine)
+
+    test.batch.run.property.query[functional-tomcat90-hypersonic20-jdk8][upstream-dxp]=\
+        (app.server.types == null OR app.server.types ~ tomcat) AND \
+        (database.types ~ hypersonic) AND \
+        (portal.upstream == true OR portal.upstream == quarantine)
+
+    test.batch.run.property.query[functional-tomcat90-mariadb102-jdk8][upstream-dxp]=\
+        (app.server.types == null OR app.server.types ~ tomcat) AND \
+        (database.types ~ mariadb) AND \
+        (portal.upstream == true OR portal.upstream == quarantine)
+
+    test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][upstream-dxp]=\
+        (app.server.types == null OR app.server.types ~ tomcat) AND \
+        (database.types == null OR database.types ~ mysql) AND \
+        (portal.upstream == true OR portal.upstream == quarantine)
+
+    test.batch.run.property.query[functional-tomcat90-oracle122-jdk8][upstream-dxp]=\
+        (app.server.types == null OR app.server.types ~ tomcat) AND \
+        (database.types ~ oracle) AND \
+        (portal.upstream == true OR portal.upstream == quarantine)
+
+    test.batch.run.property.query[functional-tomcat90-postgresql10-jdk8][upstream-dxp]=\
+        (app.server.types == null OR app.server.types ~ tomcat) AND \
+        (database.types ~ postgresql) AND \
+        (portal.upstream == true OR portal.upstream == quarantine)
+
+    test.batch.run.property.query[functional-tomcat90-sybase160-jdk8][upstream-dxp]=\
+        (app.server.types == null OR app.server.types ~ tomcat) AND \
+        (database.types ~ sybase) AND \
+        (portal.upstream == true OR portal.upstream == quarantine)
+
+    #
     # WEM Modern Site Building
     #
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1300

@brianchandotcom - Can this one be backported to **7.2.x**.

Here's where I made backports:
https://github.com/brianchandotcom/liferay-portal-ee/pull/30314 (7.1.x)
https://github.com/brianchandotcom/liferay-portal-ee/pull/30315 (7.0.x)
https://github.com/brianchandotcom/liferay-portal-ee/pull/30316 (ee-6.2.x, ee-6.2.10, ee-6.1.x, & ee-6.1.30)