### PR TITLE
LRCI-1317 Allow OSB_ASAH_BACKEND_URL & FARO_URL to be configurable

### DIFF
--- a/build-test-analytics-cloud.xml
+++ b/build-test-analytics-cloud.xml
@@ -90,7 +90,14 @@ networks:
 				replace="network \&quot;${analytics.cloud.project.name}_default\&quot;"
 			/>
 
-			<echo file="${analytics.cloud.asah.dir}/local.env">OSB_ASAH_PUBLISHER_URL=${analytics.cloud.asah.publisher.url}</echo>
+			<replaceregexp
+				file="${analytics.cloud.faro.dir}/osb-faro-docker/asah-local/Dockerfile"
+				match="FARO_URL=http://localhost:8080"
+				replace="FARO_URL=${analytics.cloud.faro.frontend.url}"
+			/>
+
+			<echo file="${analytics.cloud.asah.dir}/local.env">OSB_ASAH_BACKEND_URL=${analytics.cloud.asah.backend.url}
+OSB_ASAH_PUBLISHER_URL=${analytics.cloud.asah.publisher.url}</echo>
 
 			<if>
 				<equals arg1="${analytics.cloud.asah.build}" arg2="true" />

--- a/test.properties
+++ b/test.properties
@@ -10,6 +10,7 @@
 ##
 
     analytics.cloud.asah.build=true
+    analytics.cloud.asah.backend.url=http://osbasahbackend:8080
     analytics.cloud.asah.dir=../com-liferay-osb-asah-private
     analytics.cloud.asah.prometheus.port=9091
     analytics.cloud.asah.publisher.url=http://osbasahpublisher:8080


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1317

@brianchandotcom - Can this be backported to the following branches:
* `7.2.x`
* `7.1.x`
* `7.0.x`

This allows the following env vars to be configurable:
<pre>OSB_ASAH_BACKEND_URL
OSB_ASAH_PUBLISHER_URL
FARO_URL</pre>

To set these env vars, before running:
<pre>ant -f build-test-analytics-cloud.xml start-analytics-cloud -Denv.DOCKER_ENABLED=true</pre>

Set the following properties in your `test.[hostname].properties`:
<pre>analytics.cloud.asah.backend.url=http://192.168.0.15:8086
analytics.cloud.asah.publisher.url=http://192.168.0.15:8084
analytics.cloud.faro.frontend.url=http://192.168.0.15:8081</pre>

They should map to the above environment variables.
