### PR TITLE
LRCI-1329 Remake app server logs if exists for releases | master

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -10098,6 +10098,10 @@ ANT_OPTS=${env.ANT_OPTS}</echo>
 						<include name="**/*.sh" />
 					</fileset>
 				</chmod>
+
+				<delete dir="${app.server.parent.dir}/logs" />
+
+				<mkdir dir="${app.server.parent.dir}/logs" />
 			</then>
 			<else>
 				<if>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1329

@brianchandotcom - If this looks okay can this be backported to `7.2.x`, `7.1.x`, & `7.0.x`?

<hr />

Here's the backports for the other branches:
https://github.com/brianchandotcom/liferay-portal-ee/pull/30525 (`ee-6.2.x` & `ee-6.2.10`)
https://github.com/brianchandotcom/liferay-portal-ee/pull/30526 (`ee-6.1.x` & `ee-6.1.30`)