### PR TITLE
LRCI-1567 Allow setting the 'minimum.slave.ram' poshi property | master

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -5150,6 +5150,7 @@
         liferay.training.dependency.jars,\
         marketplace.app.acceptance,\
         marketplace.staging.enabled,\
+        minimum.slave.ram,\
         openam.enabled,\
         osgi.app.includes,\
         osgi.module.configuration.file.names,\
@@ -5208,6 +5209,10 @@
         timeout.explicit.wait,\
         web.plugins.includes,\
         web.xml.timeout
+
+    test.case.available.property.values[minimum.slave.ram]=\
+        16,\
+        32
 
     test.case.available.property.values[product.team.names]=\
         Echo (Web Experience Management),\


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1567

@brianchandotcom - If this looks okay can it be backport it to `7.2.x`, `7.1.x`, & `7.0.x`