### PR TITLE
LRCI-1757 Add 'skip.upgrade-legacy-database' to the list of available properties | master

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -5217,6 +5217,7 @@
         skip.clean-app-server-deploy-dir,\
         skip.install-patch,\
         skip.start-app-server,\
+        skip.upgrade-legacy-database,\
         socks.proxy.enabled,\
         socks.proxy.hosts,\
         solr.enabled,\


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1757

@brianchandotcom - If this looks okay can this be backported to `7.2.x`, `7.1.x`, & `7.0.x`