### PR TITLE
LRCI-1795 Put the full path for default test.base.dir.name in poshi | master

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -9167,7 +9167,7 @@ auto.deploy.dest.dir=C:/WINDOWS/system32/config/systemprofile/liferay/websphere-
 			</then>
 			<else>
 				<echo append="true" file="${test.ext.properties.file}">
-					test.base.dir.name=test/
+					test.base.dir.name=${basedir.unix}/portal-web/test/functional/com/liferay/portalweb/
 				</echo>
 			</else>
 		</if>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1795

@brianchandotcom - If this looks okay can this be backported to `7.2.x`, `7.1.x`, & `7.0.x`.