### PR TITLE
LRCI-1839 Replace usage of 'package.file.name' within spira properties | master

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -1896,7 +1896,7 @@
 
     test.batch.spira.build.description=$(jenkins.report.url)
     test.batch.spira.build.name=$(jenkins.master.hostname)/$(jenkins.job.name)/$(jenkins.build.number) - $(jenkins.build.start)
-    test.batch.spira.build.name[test-plugins-marketplaceapp]=$(package.file.name) - $(jenkins.master.hostname)/$(jenkins.job.name)/$(jenkins.build.number) - $(jenkins.build.start)
+    test.batch.spira.build.name[test-plugins-marketplaceapp]=$(plugin.name) - $(jenkins.master.hostname)/$(jenkins.job.name)/$(jenkins.build.number) - $(jenkins.build.start)
     test.batch.spira.build.name[test-portal-acceptance-pullrequest(*]=$(portal.branch.name) - $(pull.request.sender.username) > $(pull.request.receiver.username) - PR#$(pull.request.number) - $(jenkins.build.start)
     test.batch.spira.build.name[test-portal-source-format]=${test.batch.spira.build.name[test-portal-acceptance-pullrequest(*]}
     test.batch.spira.enabled[test-plugins-acceptance-pullrequest(*]=true


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1839

@brianchandotcom - If this looks okay can this be backported to `7.3.x`, `7.2.x`, `7.1.x`, & `7.0.x`