### PR TITLE
LRCI-2004 Explicitly set the Analytics Cloud tests to 32gb slaves | master

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/abtest/CreateABTest.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/abtest/CreateABTest.testcase
@@ -4,6 +4,7 @@ definition {
 	// Ignore test until Analytics Cloud connection is fully automated
 
 	property analytics.cloud.enabled = "true";
+	property minimum.slave.ram = "32";
 	property portal.release = "false";
 	property portal.upstream = "false";
 	property testray.main.component.name = "A/B Test";


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-2004

@brianchandotcom - This is the update in response to this [pull](https://github.com/brianchandotcom/liferay-portal/pull/99159#issuecomment-785153963). If this looks okay can this be backported to `7.3.x`?

cc: @CarlosBrichete