### PR TITLE
LRCI-2112 Fix portal acceptance upstream testray build name

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -5700,7 +5700,7 @@
     testray.build.name[test-plugins-release]=$(plugins.custom.branch.username)/$(plugins.custom.branch.name) - $(plugins.sha) - $(jenkins.build.start)
     testray.build.name[test-plugins-upstream]=$(plugins.custom.branch.username)/$(plugins.custom.branch.name) - $(plugins.sha) - $(jenkins.build.start)
     testray.build.name[test-portal-acceptance-pullrequest(*)]=[$(portal.branch.name)] ci:test:$(ci.test.suite) - $(pull.request.sender.username) > $(pull.request.receiver.username) - PR#$(pull.request.number) - $(jenkins.build.start)
-    testray.build.name[test-portal-acceptance-upstream-dxp(*)]=EE Development Acceptance ($(portal.branch.name)) - $(jenkins.build.number) - ${testray.timestamp}
+    testray.build.name[test-portal-acceptance-upstream-dxp(*)]=EE Development Acceptance ($(portal.branch.name)) - $(jenkins.build.number) - $(testray.timestamp)
     testray.build.name[test-portal-app-release]=$(portal.app.name) - $(portal.release.name) - $(jenkins.build.number) - $(jenkins.build.start)
     testray.build.name[test-portal-environment(*)]=Environment Acceptance ($(portal.branch.name)) - $(jenkins.build.number) - $(jenkins.build.start)
     testray.build.name[test-portal-environment-release(*)]=$(portal.type) Environment Package Tester - $(jenkins.build.number) - $(jenkins.build.start)


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-2112

@brianchandotcom - If this looks okay, can this be backported to `7.3.x`, `7.2.x`, `7.1.x`, `7.0.x`, `ee-6.2.x`, `ee-6.2.10`, `ee-6.1.x`, & `ee-6.1.30`?