### PR TITLE
LRCI-2274 Fix 'print-file' macrodef when no line count is not set | master

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -3205,7 +3205,7 @@ tell application "Safari" to quit
 					int fileLineCount = getFileLineCount();
 
 					for (int i = 0; i < fileLines.length; i++) {
-						if (fileLineCount <= i) {
+						if ((fileLineCount != -1) && (fileLineCount <= i)) {
 							break;
 						}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-2274

@brianchandotcom - If this looks okay can this be backported to `7.3.x`, `7.2.x`, `7.1.x`, & `7.0.x`?