### PR TITLE
LRCI-1867 Move away from Testray 2 until it has been restored

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -5952,7 +5952,7 @@
     testray.slack.username[test-portal-hotfix-release]=Hotfix Release Build
     testray.slack.username[test-portal-release]=Release Build
 
-    testray.server.url=https://webserver-testray-dev.lfr.cloud
+    testray.server.url=https://testray.liferay.com
 
     testray.team.internal.component.names=\
         Grow


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1867

@brianchandotcom - If this looks okay can this be backported to `7.3.x`, `7.2.x`, `7.1.x`, `7.0.x`, `ee-6.2.x`, `ee-6.2.10`, `ee-6.1.x`, & `ee-6.1.30`?