### PR TITLE
LRCI-2468 Update slave properties for minimum ram & fix the slave label | master

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -5732,9 +5732,7 @@
 
     test.case.available.property.values[minimum.slave.ram]=\
         12,\
-        16,\
-        24,\
-        32
+        24
 
     test.case.available.property.values[property.group]=\
         analytics.cloud.profile

--- a/test.properties
+++ b/test.properties
@@ -5754,7 +5754,7 @@
 
      test.case.property.group[analytics.cloud.profile][analytics.cloud.enabled]=true
      test.case.property.group[analytics.cloud.profile][minimum.slave.ram]=24
-     test.case.property.group[analytics.cloud.profile][slave.lable]=slave-1
+     test.case.property.group[analytics.cloud.profile][slave.label]=slave-1
 
 ##
 ## Test Class Groups


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-2468

@brianchandotcom - If this looks okay can this be backported to `7.3.x`, `7.2.x`, `7.1.x`, & `7.0.x`?