### PR TITLE
LRCI-2471 Remove reference to 24gb slave in ClusteringLink.testcase | master

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/clustering/clusteringframework/ClusteringLink.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/clustering/clusteringframework/ClusteringLink.testcase
@@ -2,7 +2,6 @@
 definition {
 
 	property cluster.enabled = "true";
-	property minimum.slave.ram = "24";
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.assert.warning.exceptions = "true";


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-2471

@brianchandotcom - If this looks okay can this be backported to `7.3.x`, `7.2.x`, & `7.1.x`?