### PR TITLE
LPS-141181 Fix NewEnvJVMTestRuleTest to include env vars that can be empty

### DIFF
--- a/portal-kernel/test/unit/com/liferay/portal/kernel/test/rule/NewEnvJVMTestRuleTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/test/rule/NewEnvJVMTestRuleTest.java
@@ -221,8 +221,10 @@ public class NewEnvJVMTestRuleTest {
 	private static Map<String, String> _getEnvironment() {
 		Map<String, String> environment = new HashMap<>(System.getenv());
 
+		environment.remove("CACHE_DIR");
 		environment.remove("MODULES_BASE_DIR_NAMES_WITH_CHANGES");
 		environment.remove("PROJECT_NAMES");
+		environment.remove("PORTAL_BUNDLES_DIST_URL");
 		environment.remove("SUBREPOSITORY_PACKAGE_NAMES");
 		environment.remove("TERMCAP");
 

--- a/test.properties
+++ b/test.properties
@@ -4564,8 +4564,7 @@
 
     test.batch.class.names.excludes[unit-jdk8][relevant]=\
         ${test.batch.class.names.excludes},\
-        **/test/**/ConfigurationEnvBuilderTest.java,\
-        **/test/**/NewEnvJVMTestRuleTest.java
+        **/test/**/ConfigurationEnvBuilderTest.java
 
     test.batch.class.names.includes.required[modules-integration-*-jdk8][relevant]=\
         ${test.batch.class.names.includes[modules-integration-*-jdk8_stable]},\


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-141181