### PR TITLE
LRCI-2626 Add 7.3.10 tomcat versions to be set

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -4294,6 +4294,9 @@ go</echo>
 						<equals arg1="@{liferay.portal.bundle}" arg2="7.1.10.5" />
 						<equals arg1="@{liferay.portal.bundle}" arg2="7.3.5" />
 						<equals arg1="@{liferay.portal.bundle}" arg2="7.3.10" />
+						<equals arg1="@{liferay.portal.bundle}" arg2="7.3.10.1" />
+						<equals arg1="@{liferay.portal.bundle}" arg2="7.3.10.2" />
+						<equals arg1="@{liferay.portal.bundle}" arg2="7.3.10.3" />
 					</or>
 					<then>
 						<var name="app.server.tomcat.version" value="9.0.37" />


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-2626

@brianchandotcom - If this looks okay can this be backported to `7.3.x`, `7.2.x`, `7.1.x`, & `7.0.x`?