### PR TITLE
LRCI-2650 Ensure the base branch sha is set even when fetching from a cached branch

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
@@ -276,6 +276,9 @@ public abstract class BaseWorkspaceGitRepository
 
 		gitWorkingDirectory.checkoutLocalGitBranch(localGitBranch);
 
+		gitWorkingDirectory.createLocalGitBranch(
+			getUpstreamBranchName(), true, getBaseBranchSHA());
+
 		gitWorkingDirectory.reset("--hard " + localGitBranch.getSHA());
 
 		gitWorkingDirectory.clean();


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-2650