### PR TITLE
LRCI-2711 Update the tomcat version to distinguish between 7.4.13 & 7.4.13.u1

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -4323,13 +4323,16 @@ go</echo>
 					</then>
 				</elseif>
 				<elseif>
-					<equals arg1="@{liferay.portal.bundle}" arg2="7.3.10.3" />
+					<or>
+						<equals arg1="@{liferay.portal.bundle}" arg2="7.3.10.3" />
+						<equals arg1="@{liferay.portal.bundle}" arg2="7.4.13" />
+					</or>
 					<then>
 						<var name="app.server.tomcat.version" value="9.0.53" />
 					</then>
 				</elseif>
 				<elseif>
-					<equals arg1="@{liferay.portal.bundle}" arg2="7.4.13" />
+					<equals arg1="@{liferay.portal.bundle}" arg2="7.4.13.u1" />
 					<then>
 						<var name="app.server.tomcat.version" value="9.0.56" />
 					</then>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-2711

@brianchandotcom - If this looks okay can this be backported to `7.3.x`, `7.2.x`, `7.1.x`, & `7.0.x`?