### PR TITLE
LRCI-2824 Add target 'prepare-chrome-driver' to be ran outside of build-test.xml | master

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -8557,6 +8557,10 @@ ${update.properties}</echo>
 		</if>
 	</target>
 
+	<target name="prepare-chrome-driver">
+		<prepare-chrome-driver />
+	</target>
+
 	<target name="prepare-encryption-PCKS12-certificate">
 		<if>
 			<equals arg1="${app.server.type}" arg2="tomcat" />


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-2824