### PR TITLE
LRCI-2969 Move the 'portal-license-smoke-jdk8' to the NUC slaves

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -1108,6 +1108,7 @@
 
     test.batch.minimum.slave.ram[analytics-cloud-cucumber-tomcat90-mysql57-jdk8]=24
     test.batch.minimum.slave.ram[modules-integration*]=24
+    test.batch.minimum.slave.ram[portal-license-smoke-jdk8]=24
 
     test.batch.names=${test.batch.names[acceptance-dxp]}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-2969