### PR TITLE
LRCI-2979 Enable downstream builds for subrepository pulls

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -1105,6 +1105,7 @@
     test.batch.downstream.enabled[test-portal-hotfix-release]=true
     test.batch.downstream.enabled[test-portal-release]=true
     test.batch.downstream.enabled[test-portal-testsuite-upstream(*)]=true
+    test.batch.downstream.enabled[test-subrepository-acceptance-pullrequest(*)]=true
 
     #test.batch.max.group.size=
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-2979

@brianchandotcom - If this looks good can this be backported to `7.3.x`, `7.2.x`, `7.1.x`, `7.0.x`, `ee-6.2.x`, `ee-6.2.10`, `ee-6.1.x`, & `ee-6.1.30`?