### PR TITLE
LRCI-2972 Enable downstream builds for portal acceptance upstream jobs

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -1106,6 +1106,8 @@
     test.batch.downstream.enabled[test-plugins-release]=true
     test.batch.downstream.enabled[test-plugins-upstream]=true
     test.batch.downstream.enabled[test-portal-acceptance-pullrequest(*)]=true
+    test.batch.downstream.enabled[test-portal-acceptance-upstream(*)]=true
+    test.batch.downstream.enabled[test-portal-acceptance-upstream-dxp(*)]=true
     test.batch.downstream.enabled[test-portal-app-release]=true
     test.batch.downstream.enabled[test-portal-fixpack-release]=true
     test.batch.downstream.enabled[test-portal-hotfix-release]=true


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-2972

@brianchandotcom - If this looks okay can this be backported to `7.3.x`, `7.2.x`, `7.1.x`, `7.0.x`, `ee-6.2.x`, `ee-6.2.10`, `ee-6.1.x`, & `ee-6.1.30`?