### PR TITLE
LRCI-2987 Add 7.1.3 reference for tomcat | master

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -6037,6 +6037,7 @@ go</echo>
 				</elseif>
 				<elseif>
 					<or>
+						<equals arg1="@{liferay.portal.bundle}" arg2="7.1.3" />
 						<equals arg1="@{liferay.portal.bundle}" arg2="7.1.10.3" />
 						<equals arg1="@{liferay.portal.bundle}" arg2="7.2.0" />
 						<equals arg1="@{liferay.portal.bundle}" arg2="7.2.1" />


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-2987

@brianchandotcom - If this looks okay can this be backported to `7.3.x` & `7.2.x`?

This change already exists within `7.1.x` & `7.0.x`.

Backport for ee branches were sent [here](https://github.com/brianchandotcom/liferay-portal-ee/pull/37252).