### PR TITLE
LRCI-2994 If the 'APP_SERVER_TOMCAT_VERSION' is set use that instead of the portal bundle | master

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -5905,10 +5905,16 @@ go</echo>
 
 		<sequential>
 			<if>
-				<equals arg1="@{liferay.portal.bundle}" arg2="6.0.6" />
+				<isset property="env.APP_SERVER_TOMCAT_VERSION" />
 				<then>
-					<var name="app.server.tomcat.version" value="6.0.29" />
+					<var name="app.server.tomcat.version" value="${env.APP_SERVER_TOMCAT_VERSION}" />
 				</then>
+				<elseif>
+					<equals arg1="@{liferay.portal.bundle}" arg2="6.0.6" />
+					<then>
+						<var name="app.server.tomcat.version" value="6.0.29" />
+					</then>
+				</elseif>
 				<elseif>
 					<equals arg1="@{liferay.portal.bundle}" arg2="6.0.12" />
 					<then>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-2994

@brianchandotcom - If this looks good can this be backported to `7.3.x`, `7.2.x`, `7.1.x`, & `7.0.x`?