### PR TITLE
LRCI-3013 Fix 'modules-compile-jdk8' for RCA Tool batch runs | master

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -5725,15 +5725,20 @@ log.sanitizer.enabled=false</echo>
 			<test-set-up>
 				<setup-test-environment />
 
-				<echo>tar --extract --file=liferay-portal-source.tar.gz modules/core/portal-bootstrap/build/system.packages.extra.mf --gzip --to-stdout--verbose > modules/core/portal-bootstrap/system.packages.extra.mf</echo>
+				<if>
+					<available file="liferay-portal-source.tar.gz" />
+					<then>
+						<echo>tar --extract --file=liferay-portal-source.tar.gz modules/core/portal-bootstrap/build/system.packages.extra.mf --gzip --to-stdout--verbose > modules/core/portal-bootstrap/system.packages.extra.mf</echo>
 
-				<execute>
-					<![CDATA[
-						mkdir -p modules/core/portal-bootstrap
+						<execute>
+							<![CDATA[
+								mkdir -p modules/core/portal-bootstrap
 
-						tar --extract --file=liferay-portal-source.tar.gz modules/core/portal-bootstrap/build/system.packages.extra.mf --gzip --to-stdout --verbose > modules/core/portal-bootstrap/system.packages.extra.mf
-					]]>
-				</execute>
+								tar --extract --file=liferay-portal-source.tar.gz modules/core/portal-bootstrap/build/system.packages.extra.mf --gzip --to-stdout --verbose > modules/core/portal-bootstrap/system.packages.extra.mf
+							]]>
+						</execute>
+					</then>
+				</if>
 			</test-set-up>
 		</run-batch-test>
 	</target>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-3013

@brianchandotcom - If this looks good can this be backported to `7.3.x`, `7.2.x`, & `7.1.x`?