### PR TITLE
LRCI-3022 Do not write the portal property verify.patch.levels.disabled for certain versions of portal

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -11102,7 +11102,19 @@ include-and-override=${liferay.home}/portal-setup-wizard.properties</echo>
 				<get-patch-requirements patch.file.zip.url="${test.build.fix.pack.zip.url}" />
 
 				<if>
-					<matches pattern="(sp|u)\d+" string="${patch.requirements}" />
+					<and>
+						<matches pattern="(sp|u)\d+" string="${patch.requirements}" />
+						<or>
+							<not>
+								<contains string="${test.portal.bundle.version}" substring="7.4" />
+							</not>
+							<equals arg1="${test.portal.bundle.version}" arg2="7.4.13" />
+							<equals arg1="${test.portal.bundle.version}" arg2="7.4.13.u1" />
+							<equals arg1="${test.portal.bundle.version}" arg2="7.4.13.u2" />
+							<equals arg1="${test.portal.bundle.version}" arg2="7.4.13.u3" />
+							<equals arg1="${test.portal.bundle.version}" arg2="7.4.13.u4" />
+						</or>
+					</and>
 					<then>
 						<echo append="true" file="portal-impl/src/portal-ext.properties">
 							verify.patch.levels.disabled=true


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-3022

@brianchandotom - If this looks okay can this be backported to `7.3.x`, `7.2.x`, `7.1.x`, & `7.0.x`?