### PR TITLE
LRCI-3313 Add logic to balance the junit test class groups with new metrics #2377

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BalancedListSplitter.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BalancedListSplitter.java
@@ -1,0 +1,180 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.TreeSet;
+
+/**
+ * @author Peter Yoo
+ */
+public abstract class BalancedListSplitter<T> {
+
+	public BalancedListSplitter(long maxListWeight) {
+		_maxListWeight = maxListWeight;
+	}
+
+	public abstract long getWeight(T item);
+
+	public List<List<T>> split(List<T> list) {
+		ListItemTreeSet listItems = new ListItemTreeSet();
+
+		for (T item : list) {
+			listItems.add(new ListItem(item));
+		}
+
+		long totalWeight = listItems.getWeight();
+
+		int minNumberOfLists = (int)(totalWeight / _maxListWeight);
+
+		if ((totalWeight % _maxListWeight) > 0) {
+			minNumberOfLists++;
+		}
+
+		List<ListItemTreeSet> listItemSortedSetList =
+			_createListItemSortedSetList(minNumberOfLists);
+
+		for (ListItem listItem : listItems) {
+			Collections.sort(listItemSortedSetList);
+
+			ListItemTreeSet emptiestListItemSortedSet =
+				listItemSortedSetList.get(0);
+
+			if (emptiestListItemSortedSet.getAvailableWeight() >=
+					listItem.weight) {
+
+				emptiestListItemSortedSet.add(listItem);
+
+				continue;
+			}
+
+			ListItemTreeSet newListItemSortedSet = new ListItemTreeSet(
+				_maxListWeight);
+
+			newListItemSortedSet.add(listItem);
+
+			listItemSortedSetList.add(newListItemSortedSet);
+		}
+
+		List<List<T>> lists = new ArrayList<>(listItemSortedSetList.size());
+
+		for (ListItemTreeSet listItemSortedSet : listItemSortedSetList) {
+			lists.add(listItemSortedSet.toList());
+		}
+
+		return lists;
+	}
+
+	private List<ListItemTreeSet> _createListItemSortedSetList(int size) {
+		List<ListItemTreeSet> listItemSortedSetList = new ArrayList<>();
+
+		for (int i = 0; i < size; i++) {
+			listItemSortedSetList.add(new ListItemTreeSet(_maxListWeight));
+		}
+
+		return listItemSortedSetList;
+	}
+
+	private final long _maxListWeight;
+
+	private class ListItem implements Comparable<ListItem> {
+
+		public ListItem(T item) {
+			this.item = item;
+			weight = getWeight(item);
+		}
+
+		@Override
+		public int compareTo(ListItem otherListItem) {
+			return -1 * weight.compareTo(otherListItem.weight);
+		}
+
+		public T item;
+		public Long weight;
+
+	}
+
+	private class ListItemTreeSet
+		extends TreeSet<ListItem> implements Comparable<ListItemTreeSet> {
+
+		public ListItemTreeSet() {
+		}
+
+		public ListItemTreeSet(Long targetWeight) {
+			_targetWeight = targetWeight;
+		}
+
+		@Override
+		public int compareTo(ListItemTreeSet otherListItemSortedSet) {
+			Long availableWeight = getAvailableWeight();
+			Long otherAvailableWeight =
+				otherListItemSortedSet.getAvailableWeight();
+
+			if ((availableWeight == null) && (otherAvailableWeight == null)) {
+				return 0;
+			}
+
+			if (availableWeight == null) {
+				return 1;
+			}
+
+			if (otherAvailableWeight == null) {
+				return -1;
+			}
+
+			return -1 * availableWeight.compareTo(otherAvailableWeight);
+		}
+
+		public Long getAvailableWeight() {
+			if (_targetWeight == null) {
+				return null;
+			}
+
+			long availableWeight = _targetWeight - getWeight();
+
+			if (availableWeight <= 0) {
+				return 0L;
+			}
+
+			return availableWeight;
+		}
+
+		public long getWeight() {
+			long weight = 0;
+
+			for (ListItem listItem : this) {
+				weight += listItem.weight;
+			}
+
+			return weight;
+		}
+
+		public List<T> toList() {
+			List<T> list = new ArrayList<>(size());
+
+			for (ListItem listItem : this) {
+				list.add(listItem.item);
+			}
+
+			return list;
+		}
+
+		private Long _targetWeight;
+
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BalancedListSplitter.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BalancedListSplitter.java
@@ -54,8 +54,9 @@ public abstract class BalancedListSplitter<T> {
 			ListItemTreeSet emptiestListItemSortedSet =
 				listItemSortedSetList.get(0);
 
-			if (emptiestListItemSortedSet.getAvailableWeight() >=
-					listItem.weight) {
+			if (emptiestListItemSortedSet.isEmpty() ||
+				(emptiestListItemSortedSet.getAvailableWeight() >=
+					listItem.weight)) {
 
 				emptiestListItemSortedSet.add(listItem);
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/TestClassBalancedListSplitter.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/TestClassBalancedListSplitter.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.jenkins.results.parser.test.clazz;
+
+import com.liferay.jenkins.results.parser.BalancedListSplitter;
+
+/**
+ * @author Peter Yoo
+ */
+public class TestClassBalancedListSplitter
+	extends BalancedListSplitter<TestClass> {
+
+	public TestClassBalancedListSplitter(long maxListWeight) {
+		super(maxListWeight);
+	}
+
+	@Override
+	public long getWeight(TestClass item) {
+		return item.getAverageDuration() + item.getAverageOverheadDuration();
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/BaseTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/BaseTestClassGroup.java
@@ -63,6 +63,12 @@ public abstract class BaseTestClassGroup implements TestClassGroup {
 		}
 	}
 
+	protected void addTestClasses(List<TestClass> testClasses) {
+		for (TestClass testClass : testClasses) {
+			addTestClass(testClass);
+		}
+	}
+
 	protected String getBuildStartProperty(String propertyName) {
 		BuildDatabase buildDatabase = BuildDatabaseUtil.getBuildDatabase();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/BatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/BatchTestClassGroup.java
@@ -37,6 +37,7 @@ import java.nio.file.PathMatcher;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -831,6 +832,23 @@ public abstract class BatchTestClassGroup extends BaseTestClassGroup {
 		}
 
 		private List<Row> _csvReportRows = new ArrayList<>();
+
+	}
+
+	protected static class TestClassDurationComparator
+		implements Comparator<TestClass> {
+
+		@Override
+		public int compare(TestClass testClass1, TestClass testClass2) {
+			Long duration1 =
+				testClass1.getAverageDuration() +
+					testClass1.getAverageOverheadDuration();
+			Long duration2 =
+				testClass2.getAverageDuration() +
+					testClass2.getAverageOverheadDuration();
+
+			return duration2.compareTo(duration1);
+		}
 
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/FunctionalBatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/FunctionalBatchTestClassGroup.java
@@ -32,7 +32,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -118,23 +117,6 @@ public class FunctionalBatchTestClassGroup extends BatchTestClassGroup {
 		}
 
 		return testClasses;
-	}
-
-	public static class TestClassDurationComparator
-		implements Comparator<TestClass> {
-
-		@Override
-		public int compare(TestClass testClass1, TestClass testClass2) {
-			Long duration1 =
-				testClass1.getAverageDuration() +
-					testClass1.getAverageOverheadDuration();
-			Long duration2 =
-				testClass2.getAverageDuration() +
-					testClass2.getAverageOverheadDuration();
-
-			return duration2.compareTo(duration1);
-		}
-
 	}
 
 	protected FunctionalBatchTestClassGroup(


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-3313

@michaelhashimoto I added some code to try to simplify the way the test class groups are balanced and do it in a way such that the logic can be reusable. 

Here's how I tested it locally:
```
	public static void main(String[] args) {
		BalancedListSplitter<Long> listSplitter = new BalancedListSplitter<Long>(50L) {
			@Override
			public long getWeight(Long item) {
				return item;
			}
			
		};

		List<List<Long>> lists = listSplitter.split(
			Arrays.asList(
				1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L, 12L, 13L, 14L,
				15L, 16L, 17L, 20L, 18L, 17L, 12L, 20L));

		int i = 1;
		for (List<Long> list : lists) {
			printList(i, list);
			i++;
		}
	}
```

This code produced the following output:

```
1: [16, 15, 9, 6, 1] : total: 47
2: [20, 12, 8, 7] : total: 47
3: [17, 14, 10, 5, 2] : total: 48
4: [18, 13, 11, 4, 3] : total: 49
```

Let me know what you think.