### PR TITLE
Revert "subrepo:ignore Fix sync"

### DIFF
--- a/modules/etl/mulesoft/.gitrepo
+++ b/modules/etl/mulesoft/.gitrepo
@@ -4,5 +4,5 @@
 	commit = c221310c4b0b845dfedfc4bdfeb8618682f3df10
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 0000000000000000000000000000000000000000
+	parent = 95f19d5d2751f8633a767ba4ae3b8cb4641592f1
 	remote = git@github.com:liferay/liferay-etl-mulesoft.git


### PR DESCRIPTION
@brianchandotcom - I've been watching `modules/etl/mulesoft`, and I've noticed that it still has not changed back.  In retrospect I believe it fixed itself with this commit even after you did the force push:
https://github.com/liferay/liferay-portal/commit/73fd183115c76de8987c8c692b0d0dcc6fa42e47

I think we should just revert my change, and just go back to how it was before.  I think intervention is probably only needed for the pull type repositories.