### PR TITLE
LRCI-3907 Fix tomcat zip name for modules integration tests

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -6996,7 +6996,7 @@ go</echo>
 					<var name="app.server.tomcat.portal.dir" value="${app.server.parent.dir}/tomcat/webapps/ROOT" />
 					<var name="app.server.tomcat.temp.dir" value="${app.server.parent.dir}/tomcat/temp" />
 					<var name="app.server.tomcat.work.dir" value="${app.server.parent.dir}/tomcat/work" />
-					<var name="app.server.tomcat.zip.name" value="apache-tomcat.zip" />
+					<var name="app.server.tomcat.zip.name" value="apache-tomcat-${app.server.tomcat.version}.zip" />
 				</then>
 				<else>
 					<var name="app.server.tomcat.dir" value="${app.server.parent.dir}/tomcat-${app.server.tomcat.version}" />


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-3907

@brianchandotcom - If this looks okay can this be backported to the release branches?

* https://github.com/brianchandotcom/liferay-portal-ee/tree/release-7.4.13.104
* https://github.com/brianchandotcom/liferay-portal-ee/tree/release-2023.q3
* https://github.com/brianchandotcom/liferay-portal-ee/tree/release-2023.q4

It is important for release testing.