### PR TITLE
LRCI-6259 Avoid reading sha512 files when looking for cached reports

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/BatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/BatchTestClassGroup.java
@@ -273,6 +273,12 @@ public abstract class BatchTestClassGroup extends BaseTestClassGroup {
 
 		for (File buildReportFile : buildReportFiles) {
 			try {
+				String buildReportFileName = buildReportFile.getName();
+
+				if (buildReportFileName.endsWith(".sha512")) {
+					continue;
+				}
+
 				String buildReportFileContent = JenkinsResultsParserUtil.read(
 					buildReportFile);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-6259