### PR TITLE
LRCI-6956 Add Testray case and component lookups by name with caching

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BatchBuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BatchBuildTestrayCaseResult.java
@@ -263,6 +263,67 @@ public class BatchBuildTestrayCaseResult
 	}
 
 	@Override
+	public TestrayCase getTestrayCase() {
+		TestrayCase testrayCase = super.getTestrayCase();
+
+		if (testrayCase != null) {
+			return testrayCase;
+		}
+
+		String name = getName();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(name)) {
+			return null;
+		}
+
+		String type = getType();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(type)) {
+			return null;
+		}
+
+		TestrayServer testrayServer = getTestrayServer();
+
+		TestrayCaseType testrayCaseType =
+			testrayServer.getTestrayCaseTypeByName(type);
+
+		if (testrayCaseType == null) {
+			return null;
+		}
+
+		TestrayBuild testrayBuild = getTestrayBuild();
+
+		TestrayProject testrayProject = testrayBuild.getTestrayProject();
+
+		return testrayProject.getTestrayCase(name, testrayCaseType);
+	}
+
+	@Override
+	public TestrayComponent getTestrayComponent() {
+		TestrayComponent testrayComponent = super.getTestrayComponent();
+
+		if (testrayComponent != null) {
+			return testrayComponent;
+		}
+
+		String componentName = getComponentName();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(componentName)) {
+			return null;
+		}
+
+		TestrayBuild testrayBuild = getTestrayBuild();
+
+		if (testrayBuild == null) {
+			return null;
+		}
+
+		TestrayProject testrayProject = testrayBuild.getTestrayProject();
+
+		return testrayProject.getTestrayComponentByName(componentName);
+	}
+
+	@Override
 	public String getType() {
 		try {
 			return JenkinsResultsParserUtil.getProperty(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BatchBuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BatchBuildTestrayCaseResult.java
@@ -320,7 +320,12 @@ public class BatchBuildTestrayCaseResult
 
 		TestrayProject testrayProject = testrayBuild.getTestrayProject();
 
-		return testrayProject.getTestrayComponentByName(componentName);
+		testrayComponent = testrayProject.getTestrayComponentByName(
+			componentName);
+
+		setTestrayComponent(testrayComponent);
+
+		return testrayComponent;
 	}
 
 	@Override

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayBuild.java
@@ -19,6 +19,7 @@ import java.text.SimpleDateFormat;
 
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -315,6 +316,32 @@ public class TestrayBuild implements Comparable<TestrayBuild> {
 		return null;
 	}
 
+	public synchronized Long getTestrayRunID(TestrayRun testrayRun) {
+		String testrayRunIDString = testrayRun.getRunIDString();
+
+		Long testrayRunID = _testrayRunIDs.get(testrayRunIDString);
+
+		if (testrayRunID != null) {
+			return testrayRunID;
+		}
+
+		JSONObject testrayRunJSONObject = _getTestrayRunJSONObject(testrayRun);
+
+		if ((testrayRunJSONObject == null) || !testrayRunJSONObject.has("id")) {
+			return null;
+		}
+
+		testrayRunID = testrayRunJSONObject.optLong("id");
+
+		if (testrayRunID <= 0) {
+			return null;
+		}
+
+		_testrayRunIDs.put(testrayRunIDString, testrayRunID);
+
+		return testrayRunID;
+	}
+
 	public synchronized List<TestrayRun> getTestrayRuns() {
 		if (_testrayRuns != null) {
 			return _testrayRuns;
@@ -337,8 +364,18 @@ public class TestrayBuild implements Comparable<TestrayBuild> {
 			for (int i = 0; i < itemsJSONArray.length(); i++) {
 				JSONObject itemJSONObject = itemsJSONArray.getJSONObject(i);
 
-				_testrayRuns.add(
-					TestrayFactory.newTestrayRun(this, itemJSONObject));
+				TestrayRun testrayRun = TestrayFactory.newTestrayRun(
+					this, itemJSONObject);
+
+				_testrayRuns.add(testrayRun);
+
+				long testrayRunID = itemJSONObject.optLong("id");
+
+				if (testrayRunID <= 0) {
+					continue;
+				}
+
+				_testrayRunIDs.put(testrayRun.getRunIDString(), testrayRunID);
 			}
 		}
 		catch (IOException ioException) {
@@ -548,6 +585,38 @@ public class TestrayBuild implements Comparable<TestrayBuild> {
 		return null;
 	}
 
+	private JSONObject _getTestrayRunJSONObject(TestrayRun testrayRun) {
+		String runIDString = testrayRun.getRunIDString();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(runIDString)) {
+			return null;
+		}
+
+		TestrayServer testrayServer = getTestrayServer();
+
+		String filter = JenkinsResultsParserUtil.combine(
+			"name eq '", runIDString, "' and r_buildToRuns_c_buildId eq '",
+			String.valueOf(getID()), "'");
+
+		try {
+			Set<JSONObject> entityJSONObjects = testrayServer.requestGraphQL(
+				"runs", TestrayRun.FIELD_NAMES, filter, null, 1, 1);
+
+			for (JSONObject entityJSONObject : entityJSONObjects) {
+				if (entityJSONObject == null) {
+					continue;
+				}
+
+				return entityJSONObject;
+			}
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(ioException);
+		}
+
+		return null;
+	}
+
 	private static final Pattern _portalBranchPattern = Pattern.compile(
 		"Portal Branch: (?<portalBranch>[^;]+);");
 	private static final Pattern _testrayAttachmentURLPattern = Pattern.compile(
@@ -558,6 +627,7 @@ public class TestrayBuild implements Comparable<TestrayBuild> {
 	private static final Pattern _testrayBuildURLPattern = Pattern.compile(
 		"(?<serverURL>https://[^/]+)/#/project/(?<projectID>\\d+)/routines/" +
 			"(?<routineID>\\d+)/build/(?<buildID>\\d+)");
+	private static final Map<String, Long> _testrayRunIDs = new HashMap<>();
 
 	private final JSONObject _jsonObject;
 	private String _pullRequestSenderUsername;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayBuild.java
@@ -508,12 +508,12 @@ public class TestrayBuild implements Comparable<TestrayBuild> {
 		_testrayRoutine = _testrayServer.getTestrayRoutineByID(
 			Long.parseLong(matcher.group("routineID")));
 
-		String filter = JenkinsResultsParserUtil.combine(
+		String filterString = JenkinsResultsParserUtil.combine(
 			"id eq '", matcher.group("buildID"), "'");
 
 		try {
 			Set<JSONObject> entityJSONObjects = _testrayServer.requestGraphQL(
-				"builds", FIELD_NAMES, filter, null, 1, 1);
+				"builds", FIELD_NAMES, filterString, null, 1, 1);
 
 			if (entityJSONObjects.isEmpty()) {
 				throw new RuntimeException("Unable to find entity JSON object");
@@ -594,13 +594,13 @@ public class TestrayBuild implements Comparable<TestrayBuild> {
 
 		TestrayServer testrayServer = getTestrayServer();
 
-		String filter = JenkinsResultsParserUtil.combine(
+		String filterString = JenkinsResultsParserUtil.combine(
 			"name eq '", runIDString, "' and r_buildToRuns_c_buildId eq '",
 			String.valueOf(getID()), "'");
 
 		try {
 			Set<JSONObject> entityJSONObjects = testrayServer.requestGraphQL(
-				"runs", TestrayRun.FIELD_NAMES, filter, null, 1, 1);
+				"runs", TestrayRun.FIELD_NAMES, filterString, null, 1, 1);
 
 			for (JSONObject entityJSONObject : entityJSONObjects) {
 				if (entityJSONObject == null) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayBuild.java
@@ -369,7 +369,7 @@ public class TestrayBuild implements Comparable<TestrayBuild> {
 
 				_testrayRuns.add(testrayRun);
 
-				long testrayRunID = itemJSONObject.optLong("id");
+				long testrayRunID = testrayRun.getID();
 
 				if (testrayRunID <= 0) {
 					continue;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCaseResult.java
@@ -263,21 +263,35 @@ public class TestrayCaseResult {
 		return testrayCaseResults;
 	}
 
+	public URL getTestrayCaseResultURL() {
+		if (_testrayCaseResultURL != null) {
+			return _testrayCaseResultURL;
+		}
+
+		_testrayCaseResultURL = _getCachedTestrayCaseResultURL();
+
+		return _testrayCaseResultURL;
+	}
+
 	public TestrayComponent getTestrayComponent() {
 		if (_testrayComponent != null) {
 			return _testrayComponent;
 		}
 
+		TestrayBuild testrayBuild = getTestrayBuild();
+
+		TestrayProject testrayProject = testrayBuild.getTestrayProject();
+
 		JSONObject componentJSONObject = _jsonObject.optJSONObject(
 			"componentToCaseResult");
 
 		if (componentJSONObject != null) {
-			TestrayBuild testrayBuild = getTestrayBuild();
-
-			TestrayProject testrayProject = testrayBuild.getTestrayProject();
-
 			_testrayComponent = testrayProject.getTestrayComponentByID(
 				componentJSONObject.getLong("id"));
+		}
+		else {
+			_testrayComponent = testrayProject.getTestrayComponentByName(
+				getComponentName());
 		}
 
 		return _testrayComponent;
@@ -289,8 +303,36 @@ public class TestrayCaseResult {
 		return testrayBuild.getTestrayProject();
 	}
 
+	public TestrayRun getTestrayRun() {
+		return _testrayRun;
+	}
+
 	public TestrayServer getTestrayServer() {
 		return _testrayServer;
+	}
+
+	public TestrayTeam getTestrayTeam() {
+		if (_testrayTeam != null) {
+			return _testrayTeam;
+		}
+
+		String teamName = getTeamName();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(teamName)) {
+			return null;
+		}
+
+		TestrayBuild testrayBuild = getTestrayBuild();
+
+		if (testrayBuild == null) {
+			return null;
+		}
+
+		TestrayProject testrayProject = testrayBuild.getTestrayProject();
+
+		_testrayTeam = testrayProject.getTestrayTeamByName(teamName);
+
+		return _testrayTeam;
 	}
 
 	public String getType() {
@@ -316,6 +358,10 @@ public class TestrayCaseResult {
 
 	public String[] getWarnings() {
 		return null;
+	}
+
+	public void setTestrayRun(TestrayRun testrayRun) {
+		_testrayRun = testrayRun;
 	}
 
 	public static enum ErrorType {
@@ -461,6 +507,76 @@ public class TestrayCaseResult {
 
 	protected Map<String, TestrayAttachment> testrayAttachments;
 
+	private URL _getCachedTestrayCaseResultURL() {
+		TestrayBuild testrayBuild = getTestrayBuild();
+
+		if (testrayBuild == null) {
+			return null;
+		}
+
+		TestrayCase testrayCase = getTestrayCase();
+
+		if (testrayCase == null) {
+			return null;
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("r_buildToCaseResult_c_buildId eq '");
+		sb.append(testrayBuild.getID());
+		sb.append("' and r_caseToCaseResult_c_caseId eq '");
+		sb.append(testrayCase.getID());
+		sb.append("'");
+
+		TestrayComponent testrayComponent = getTestrayComponent();
+
+		if (testrayComponent != null) {
+			sb.append(" and r_componentToCaseResult_c_componentId eq '");
+			sb.append(testrayComponent.getID());
+			sb.append("'");
+		}
+
+		TestrayRun testrayRun = getTestrayRun();
+
+		if (testrayRun != null) {
+			sb.append(" and r_runToCaseResult_c_runId eq '");
+			sb.append(testrayRun.getID());
+			sb.append("'");
+		}
+
+		TestrayTeam testrayTeam = getTestrayTeam();
+
+		if (testrayTeam != null) {
+			sb.append(" and r_teamToCaseResult_c_teamId eq '");
+			sb.append(testrayTeam.getID());
+			sb.append("'");
+		}
+
+		try {
+			Set<JSONObject> entityJSONObjects = _testrayServer.requestGraphQL(
+				"caseResults", FIELD_NAMES, sb.toString(), null, 1, 1);
+
+			if (entityJSONObjects.isEmpty()) {
+				return null;
+			}
+
+			for (JSONObject entityJSONObject : entityJSONObjects) {
+				if (entityJSONObject == null) {
+					continue;
+				}
+
+				return new URL(
+					testrayBuild.getURL() + "/case-result/" +
+						entityJSONObject.getLong("id"));
+			}
+
+			return null;
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(ioException);
+		}
+	}
+
 	private boolean _isSimilarError(
 		TestrayCaseResult previousTestrayCaseResult) {
 
@@ -494,7 +610,10 @@ public class TestrayCaseResult {
 	private final JSONObject _jsonObject;
 	private TestrayBuild _testrayBuild;
 	private TestrayCase _testrayCase;
+	private URL _testrayCaseResultURL;
 	private TestrayComponent _testrayComponent;
+	private TestrayRun _testrayRun;
 	private final TestrayServer _testrayServer;
+	private TestrayTeam _testrayTeam;
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCaseResult.java
@@ -203,22 +203,35 @@ public class TestrayCaseResult {
 		return _testrayBuild;
 	}
 
-	public TestrayCase getTestrayCase() {
+	public synchronized TestrayCase getTestrayCase() {
 		if (_testrayCase != null) {
 			return _testrayCase;
 		}
 
-		JSONObject caseJSONObject = _jsonObject.optJSONObject(
-			"caseToCaseResult");
-
-		if (caseJSONObject != null) {
-			TestrayBuild testrayBuild = getTestrayBuild();
-
-			_testrayCase = TestrayFactory.newTestrayCase(
-				testrayBuild.getTestrayProject(), caseJSONObject);
+		if (_resolvingTestrayCase) {
+			return null;
 		}
 
-		return _testrayCase;
+		_resolvingTestrayCase = true;
+
+		try {
+			if (_jsonObject != null) {
+				JSONObject caseJSONObject = _jsonObject.optJSONObject(
+					"caseToCaseResult");
+
+				if (caseJSONObject != null) {
+					TestrayBuild testrayBuild = getTestrayBuild();
+
+					_testrayCase = TestrayFactory.newTestrayCase(
+						testrayBuild.getTestrayProject(), caseJSONObject);
+				}
+			}
+
+			return _testrayCase;
+		}
+		finally {
+			_resolvingTestrayCase = false;
+		}
 	}
 
 	public List<TestrayCaseResult> getTestrayCaseResultHistory(
@@ -273,36 +286,47 @@ public class TestrayCaseResult {
 		return _testrayCaseResultURL;
 	}
 
-	public TestrayComponent getTestrayComponent() {
+	public synchronized TestrayComponent getTestrayComponent() {
 		if (_testrayComponent != null) {
 			return _testrayComponent;
 		}
 
-		TestrayBuild testrayBuild = getTestrayBuild();
-
-		if (testrayBuild == null) {
+		if (_resolvingTestrayComponent) {
 			return null;
 		}
 
-		TestrayProject testrayProject = testrayBuild.getTestrayProject();
+		_resolvingTestrayComponent = true;
 
-		JSONObject componentJSONObject = null;
+		try {
+			TestrayBuild testrayBuild = getTestrayBuild();
 
-		if (_jsonObject != null) {
-			componentJSONObject = _jsonObject.optJSONObject(
-				"componentToCaseResult");
+			if (testrayBuild == null) {
+				return null;
+			}
+
+			TestrayProject testrayProject = testrayBuild.getTestrayProject();
+
+			JSONObject componentJSONObject = null;
+
+			if (_jsonObject != null) {
+				componentJSONObject = _jsonObject.optJSONObject(
+					"componentToCaseResult");
+			}
+
+			if (componentJSONObject != null) {
+				_testrayComponent = testrayProject.getTestrayComponentByID(
+					componentJSONObject.getLong("id"));
+			}
+			else {
+				_testrayComponent = testrayProject.getTestrayComponentByName(
+					getComponentName());
+			}
+
+			return _testrayComponent;
 		}
-
-		if (componentJSONObject != null) {
-			_testrayComponent = testrayProject.getTestrayComponentByID(
-				componentJSONObject.getLong("id"));
+		finally {
+			_resolvingTestrayComponent = false;
 		}
-		else {
-			_testrayComponent = testrayProject.getTestrayComponentByName(
-				getComponentName());
-		}
-
-		return _testrayComponent;
 	}
 
 	public TestrayProject getTestrayProject() {
@@ -616,6 +640,8 @@ public class TestrayCaseResult {
 
 	private ErrorType _errorType;
 	private final JSONObject _jsonObject;
+	private boolean _resolvingTestrayCase;
+	private boolean _resolvingTestrayComponent;
 	private TestrayBuild _testrayBuild;
 	private TestrayCase _testrayCase;
 	private URL _testrayCaseResultURL;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCaseResult.java
@@ -392,6 +392,10 @@ public class TestrayCaseResult {
 		return null;
 	}
 
+	public void setTestrayComponent(TestrayComponent testrayComponent) {
+		_testrayComponent = testrayComponent;
+	}
+
 	public void setTestrayRun(TestrayRun testrayRun) {
 		_testrayRun = testrayRun;
 	}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCaseResult.java
@@ -280,10 +280,18 @@ public class TestrayCaseResult {
 
 		TestrayBuild testrayBuild = getTestrayBuild();
 
+		if (testrayBuild == null) {
+			return null;
+		}
+
 		TestrayProject testrayProject = testrayBuild.getTestrayProject();
 
-		JSONObject componentJSONObject = _jsonObject.optJSONObject(
-			"componentToCaseResult");
+		JSONObject componentJSONObject = null;
+
+		if (_jsonObject != null) {
+			componentJSONObject = _jsonObject.optJSONObject(
+				"componentToCaseResult");
+		}
 
 		if (componentJSONObject != null) {
 			_testrayComponent = testrayProject.getTestrayComponentByID(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCaseResult.java
@@ -208,11 +208,11 @@ public class TestrayCaseResult {
 			return _testrayCase;
 		}
 
-		if (_resolvingTestrayCase) {
+		if (_testrayCaseCached) {
 			return null;
 		}
 
-		_resolvingTestrayCase = true;
+		_testrayCaseCached = true;
 
 		try {
 			if (_jsonObject != null) {
@@ -230,7 +230,7 @@ public class TestrayCaseResult {
 			return _testrayCase;
 		}
 		finally {
-			_resolvingTestrayCase = false;
+			_testrayCaseCached = false;
 		}
 	}
 
@@ -291,11 +291,11 @@ public class TestrayCaseResult {
 			return _testrayComponent;
 		}
 
-		if (_resolvingTestrayComponent) {
+		if (_testrayComponentCached) {
 			return null;
 		}
 
-		_resolvingTestrayComponent = true;
+		_testrayComponentCached = true;
 
 		try {
 			TestrayBuild testrayBuild = getTestrayBuild();
@@ -325,7 +325,7 @@ public class TestrayCaseResult {
 			return _testrayComponent;
 		}
 		finally {
-			_resolvingTestrayComponent = false;
+			_testrayComponentCached = false;
 		}
 	}
 
@@ -644,12 +644,12 @@ public class TestrayCaseResult {
 
 	private ErrorType _errorType;
 	private final JSONObject _jsonObject;
-	private boolean _resolvingTestrayCase;
-	private boolean _resolvingTestrayComponent;
 	private TestrayBuild _testrayBuild;
 	private TestrayCase _testrayCase;
+	private boolean _testrayCaseCached;
 	private URL _testrayCaseResultURL;
 	private TestrayComponent _testrayComponent;
+	private boolean _testrayComponentCached;
 	private TestrayRun _testrayRun;
 	private final TestrayServer _testrayServer;
 	private TestrayTeam _testrayTeam;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayProject.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayProject.java
@@ -200,6 +200,10 @@ public class TestrayProject {
 
 	public TestrayComponent getTestrayComponentByName(String componentName) {
 		synchronized (_testrayComponentsID) {
+			if (JenkinsResultsParserUtil.isNullOrEmpty(componentName)) {
+				return null;
+			}
+
 			TestrayComponent testrayComponent = _testrayComponentsName.get(
 				componentName);
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayProject.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayProject.java
@@ -178,7 +178,7 @@ public class TestrayProject {
 		return null;
 	}
 
-	public List<TestrayComponent> getTestrayComponents() {
+	public synchronized List<TestrayComponent> getTestrayComponents() {
 		if (_testrayComponents != null) {
 			return _testrayComponents;
 		}
@@ -334,7 +334,7 @@ public class TestrayProject {
 		return null;
 	}
 
-	public List<TestrayTeam> getTestrayTeams() {
+	public synchronized List<TestrayTeam> getTestrayTeams() {
 		if (_testrayTeams != null) {
 			return _testrayTeams;
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayProject.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayProject.java
@@ -199,11 +199,11 @@ public class TestrayProject {
 	}
 
 	public TestrayComponent getTestrayComponentByName(String componentName) {
-		synchronized (_testrayComponentsID) {
-			if (JenkinsResultsParserUtil.isNullOrEmpty(componentName)) {
-				return null;
-			}
+		if (JenkinsResultsParserUtil.isNullOrEmpty(componentName)) {
+			return null;
+		}
 
+		synchronized (_testrayComponentsID) {
 			TestrayComponent testrayComponent = _testrayComponentsName.get(
 				componentName);
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayProject.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayProject.java
@@ -159,50 +159,82 @@ public class TestrayProject {
 	}
 
 	public TestrayComponent getTestrayComponentByID(long componentID) {
-		for (TestrayComponent testrayComponent : getTestrayComponents()) {
-			if (Objects.equals(componentID, testrayComponent.getID())) {
+		synchronized (_testrayComponentsID) {
+			TestrayComponent testrayComponent = _testrayComponentsID.get(
+				componentID);
+
+			if (testrayComponent != null) {
 				return testrayComponent;
 			}
-		}
 
-		return null;
+			String filter = JenkinsResultsParserUtil.combine(
+				"id eq '", String.valueOf(componentID),
+				"' and r_projectToComponents_c_projectId eq '",
+				String.valueOf(getID()), "'");
+
+			try {
+				Set<JSONObject> entityJSONObjects =
+					_testrayServer.requestGraphQL(
+						"components", TestrayComponent.FIELD_NAMES, filter,
+						null, 1, 1);
+
+				for (JSONObject entityJSONObject : entityJSONObjects) {
+					testrayComponent = TestrayFactory.newTestrayComponent(
+						this, entityJSONObject);
+
+					_testrayComponentsID.put(
+						testrayComponent.getID(), testrayComponent);
+					_testrayComponentsName.put(
+						testrayComponent.getName(), testrayComponent);
+
+					return testrayComponent;
+				}
+			}
+			catch (IOException ioException) {
+				throw new RuntimeException(ioException);
+			}
+
+			return null;
+		}
 	}
 
 	public TestrayComponent getTestrayComponentByName(String componentName) {
-		for (TestrayComponent testrayComponent : getTestrayComponents()) {
-			if (Objects.equals(componentName, testrayComponent.getName())) {
+		synchronized (_testrayComponentsID) {
+			TestrayComponent testrayComponent = _testrayComponentsName.get(
+				componentName);
+
+			if (testrayComponent != null) {
 				return testrayComponent;
 			}
-		}
 
-		return null;
-	}
+			String filter = JenkinsResultsParserUtil.combine(
+				"name eq '", componentName,
+				"' and r_projectToComponents_c_projectId eq '",
+				String.valueOf(getID()), "'");
 
-	public synchronized List<TestrayComponent> getTestrayComponents() {
-		if (_testrayComponents != null) {
-			return _testrayComponents;
-		}
+			try {
+				Set<JSONObject> entityJSONObjects =
+					_testrayServer.requestGraphQL(
+						"components", TestrayComponent.FIELD_NAMES, filter,
+						null, 1, 1);
 
-		_testrayComponents = new ArrayList<>();
+				for (JSONObject entityJSONObject : entityJSONObjects) {
+					testrayComponent = TestrayFactory.newTestrayComponent(
+						this, entityJSONObject);
 
-		String filter = JenkinsResultsParserUtil.combine(
-			"r_projectToComponents_c_projectId eq '", String.valueOf(getID()),
-			"'");
+					_testrayComponentsID.put(
+						testrayComponent.getID(), testrayComponent);
+					_testrayComponentsName.put(componentName, testrayComponent);
 
-		try {
-			Set<JSONObject> entityJSONObjects = _testrayServer.requestGraphQL(
-				"components", TestrayComponent.FIELD_NAMES, filter, null);
-
-			for (JSONObject entityJSONObject : entityJSONObjects) {
-				_testrayComponents.add(
-					TestrayFactory.newTestrayComponent(this, entityJSONObject));
+					return testrayComponent;
+				}
 			}
-		}
-		catch (IOException ioException) {
-			throw new RuntimeException(ioException);
-		}
+			catch (IOException ioException) {
+				throw new RuntimeException(ioException);
+			}
 
-		return _testrayComponents;
+			return null;
+		}
 	}
 
 	public TestrayProductVersion getTestrayProductVersionByID(
@@ -465,7 +497,10 @@ public class TestrayProject {
 	private final JSONObject _jsonObject;
 	private final Map<String, Long> _testrayCaseIDs = new HashMap<>();
 	private Map<String, TestrayCase> _testrayCases;
-	private List<TestrayComponent> _testrayComponents;
+	private final Map<Long, TestrayComponent> _testrayComponentsID =
+		new HashMap<>();
+	private final Map<String, TestrayComponent> _testrayComponentsName =
+		new HashMap<>();
 	private final TestrayServer _testrayServer;
 	private List<TestrayTeam> _testrayTeams;
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayProject.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayProject.java
@@ -109,7 +109,7 @@ public class TestrayProject {
 	public TestrayCase getTestrayCase(
 		String testCaseName, TestrayCaseType testrayCaseType) {
 
-		String filter = JenkinsResultsParserUtil.combine(
+		String filterString = JenkinsResultsParserUtil.combine(
 			"name eq '", testCaseName, "' and ",
 			"r_caseTypeToCases_c_caseTypeId eq '",
 			String.valueOf(testrayCaseType.getID()), "' and ",
@@ -117,7 +117,7 @@ public class TestrayProject {
 
 		try {
 			Set<JSONObject> entityJSONObjects = _testrayServer.requestGraphQL(
-				"cases", TestrayCase.FIELD_NAMES, filter, null, 1, 1);
+				"cases", TestrayCase.FIELD_NAMES, filterString, null, 1, 1);
 
 			if (entityJSONObjects.isEmpty()) {
 				return null;
@@ -167,7 +167,7 @@ public class TestrayProject {
 				return testrayComponent;
 			}
 
-			String filter = JenkinsResultsParserUtil.combine(
+			String filterString = JenkinsResultsParserUtil.combine(
 				"id eq '", String.valueOf(componentID),
 				"' and r_projectToComponents_c_projectId eq '",
 				String.valueOf(getID()), "'");
@@ -175,8 +175,8 @@ public class TestrayProject {
 			try {
 				Set<JSONObject> entityJSONObjects =
 					_testrayServer.requestGraphQL(
-						"components", TestrayComponent.FIELD_NAMES, filter,
-						null, 1, 1);
+						"components", TestrayComponent.FIELD_NAMES,
+						filterString, null, 1, 1);
 
 				for (JSONObject entityJSONObject : entityJSONObjects) {
 					testrayComponent = TestrayFactory.newTestrayComponent(
@@ -211,7 +211,7 @@ public class TestrayProject {
 				return testrayComponent;
 			}
 
-			String filter = JenkinsResultsParserUtil.combine(
+			String filterString = JenkinsResultsParserUtil.combine(
 				"name eq '", componentName,
 				"' and r_projectToComponents_c_projectId eq '",
 				String.valueOf(getID()), "'");
@@ -219,8 +219,8 @@ public class TestrayProject {
 			try {
 				Set<JSONObject> entityJSONObjects =
 					_testrayServer.requestGraphQL(
-						"components", TestrayComponent.FIELD_NAMES, filter,
-						null, 1, 1);
+						"components", TestrayComponent.FIELD_NAMES,
+						filterString, null, 1, 1);
 
 				for (JSONObject entityJSONObject : entityJSONObjects) {
 					testrayComponent = TestrayFactory.newTestrayComponent(
@@ -244,15 +244,15 @@ public class TestrayProject {
 	public TestrayProductVersion getTestrayProductVersionByID(
 		long productVersionID) {
 
-		String filter = JenkinsResultsParserUtil.combine(
+		String filterString = JenkinsResultsParserUtil.combine(
 			"id eq '", String.valueOf(productVersionID), "' and ",
 			"r_projectToProductVersions_c_projectId eq '",
 			String.valueOf(getID()), "'");
 
 		try {
 			Set<JSONObject> entityJSONObjects = _testrayServer.requestGraphQL(
-				"productVersions", TestrayProductVersion.FIELD_NAMES, filter,
-				null, 1, 1);
+				"productVersions", TestrayProductVersion.FIELD_NAMES,
+				filterString, null, 1, 1);
 
 			if (entityJSONObjects.isEmpty()) {
 				return null;
@@ -271,15 +271,15 @@ public class TestrayProject {
 	public TestrayProductVersion getTestrayProductVersionByName(
 		String productVersionName) {
 
-		String filter = JenkinsResultsParserUtil.combine(
+		String filterString = JenkinsResultsParserUtil.combine(
 			"name eq '", productVersionName, "' and ",
 			"r_projectToProductVersions_c_projectId eq '",
 			String.valueOf(getID()), "'");
 
 		try {
 			Set<JSONObject> entityJSONObjects = _testrayServer.requestGraphQL(
-				"productVersions", TestrayProductVersion.FIELD_NAMES, filter,
-				null, 1, 1);
+				"productVersions", TestrayProductVersion.FIELD_NAMES,
+				filterString, null, 1, 1);
 
 			if (entityJSONObjects.isEmpty()) {
 				return null;
@@ -303,12 +303,13 @@ public class TestrayProject {
 			return testrayRoutine;
 		}
 
-		String filter = JenkinsResultsParserUtil.combine(
+		String filterString = JenkinsResultsParserUtil.combine(
 			"id eq '", String.valueOf(routineID), "'");
 
 		try {
 			Set<JSONObject> entityJSONObjects = _testrayServer.requestGraphQL(
-				"routines", TestrayRoutine.FIELD_NAMES, filter, null, 1, 1);
+				"routines", TestrayRoutine.FIELD_NAMES, filterString, null, 1,
+				1);
 
 			if (entityJSONObjects.isEmpty()) {
 				return null;
@@ -324,14 +325,15 @@ public class TestrayProject {
 	}
 
 	public TestrayRoutine getTestrayRoutineByName(String routineName) {
-		String filter = JenkinsResultsParserUtil.combine(
+		String filterString = JenkinsResultsParserUtil.combine(
 			"name eq '", routineName, "' and ",
 			"r_routineToProjects_c_projectId eq '", String.valueOf(getID()),
 			"'");
 
 		try {
 			Set<JSONObject> entityJSONObjects = _testrayServer.requestGraphQL(
-				"routines", TestrayRoutine.FIELD_NAMES, filter, null, 1, 1);
+				"routines", TestrayRoutine.FIELD_NAMES, filterString, null, 1,
+				1);
 
 			if (entityJSONObjects.isEmpty()) {
 				return null;
@@ -377,12 +379,12 @@ public class TestrayProject {
 
 		_testrayTeams = new ArrayList<>();
 
-		String filter = JenkinsResultsParserUtil.combine(
+		String filterString = JenkinsResultsParserUtil.combine(
 			"r_projectToTeams_c_projectId eq '", String.valueOf(getID()), "'");
 
 		try {
 			Set<JSONObject> entityJSONObjects = _testrayServer.requestGraphQL(
-				"teams", TestrayTeam.FIELD_NAMES, filter, null);
+				"teams", TestrayTeam.FIELD_NAMES, filterString, null);
 
 			for (JSONObject entityJSONObject : entityJSONObjects) {
 				_testrayTeams.add(
@@ -429,12 +431,12 @@ public class TestrayProject {
 
 		_testrayCases = new HashMap<>();
 
-		String filter = JenkinsResultsParserUtil.combine(
+		String filterString = JenkinsResultsParserUtil.combine(
 			"r_projectToCases_c_projectId eq '", String.valueOf(getID()), "'");
 
 		try {
 			Set<JSONObject> entityJSONObjects = _testrayServer.requestGraphQL(
-				"cases", TestrayCase.FIELD_NAMES_CASE_IDS, filter, null);
+				"cases", TestrayCase.FIELD_NAMES_CASE_IDS, filterString, null);
 
 			for (JSONObject entityJSONObject : entityJSONObjects) {
 				_testrayCaseIDs.put(
@@ -470,12 +472,12 @@ public class TestrayProject {
 
 		_testrayCases = new HashMap<>();
 
-		String filter = JenkinsResultsParserUtil.combine(
+		String filterString = JenkinsResultsParserUtil.combine(
 			"r_projectToCases_c_projectId eq '", String.valueOf(getID()), "'");
 
 		try {
 			Set<JSONObject> entityJSONObjects = _testrayServer.requestGraphQL(
-				"cases", TestrayCase.FIELD_NAMES, filter, null, 0, 50);
+				"cases", TestrayCase.FIELD_NAMES, filterString, null, 0, 50);
 
 			for (JSONObject entityJSONObject : entityJSONObjects) {
 				TestrayCase testrayCase = TestrayFactory.newTestrayCase(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayProject.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayProject.java
@@ -106,6 +106,34 @@ public class TestrayProject {
 		return _jsonObject.getString("name");
 	}
 
+	public TestrayCase getTestrayCase(
+		String testCaseName, TestrayCaseType testrayCaseType) {
+
+		String filter = JenkinsResultsParserUtil.combine(
+			"name eq '", testCaseName, "' and ",
+			"r_caseTypeToCases_c_caseTypeId eq '",
+			String.valueOf(testrayCaseType.getID()), "' and ",
+			"r_projectToCases_c_projectId eq '", String.valueOf(getID()), "'");
+
+		try {
+			Set<JSONObject> entityJSONObjects = _testrayServer.requestGraphQL(
+				"cases", TestrayCase.FIELD_NAMES, filter, null, 1, 1);
+
+			if (entityJSONObjects.isEmpty()) {
+				return null;
+			}
+
+			for (JSONObject entityJSONObject : entityJSONObjects) {
+				return TestrayFactory.newTestrayCase(this, entityJSONObject);
+			}
+
+			return null;
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(ioException);
+		}
+	}
+
 	public TestrayCase getTestrayCaseByName(String testCaseName) {
 		_initTestrayCases();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayRoutine.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayRoutine.java
@@ -142,13 +142,27 @@ public class TestrayRoutine {
 	public TestrayBuild getTestrayBuildByName(
 		String buildName, String... names) {
 
-		String filter = JenkinsResultsParserUtil.combine(
-			"name eq '", buildName, "' and ",
-			"r_routineToBuilds_c_routineId eq '", String.valueOf(getID()), "'");
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("name eq '");
+		sb.append(buildName);
+		sb.append("'");
+
+		TestrayProject testrayProject = getTestrayProject();
+
+		if (testrayProject != null) {
+			sb.append(" and r_projectToBuilds_c_projectId eq '");
+			sb.append(testrayProject.getID());
+			sb.append("'");
+		}
+
+		sb.append(" and r_routineToBuilds_c_routineId eq '");
+		sb.append(getID());
+		sb.append("'");
 
 		try {
 			Set<JSONObject> entityJSONObjects = _testrayServer.requestGraphQL(
-				"builds", TestrayBuild.FIELD_NAMES, filter, null, 1, 1);
+				"builds", TestrayBuild.FIELD_NAMES, sb.toString(), null, 1, 1);
 
 			if (entityJSONObjects.isEmpty()) {
 				return null;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayRoutine.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayRoutine.java
@@ -142,6 +142,10 @@ public class TestrayRoutine {
 	public TestrayBuild getTestrayBuildByName(
 		String buildName, String... names) {
 
+		if (JenkinsResultsParserUtil.isNullOrEmpty(buildName)) {
+			return null;
+		}
+
 		StringBuilder sb = new StringBuilder();
 
 		sb.append("name eq '");

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayRoutine.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayRoutine.java
@@ -118,13 +118,13 @@ public class TestrayRoutine {
 			return testrayBuild;
 		}
 
-		String filter = JenkinsResultsParserUtil.combine(
+		String filterString = JenkinsResultsParserUtil.combine(
 			"id eq '", String.valueOf(buildID), "' and ",
 			"r_routineToBuilds_c_routineId eq '", String.valueOf(getID()), "'");
 
 		try {
 			Set<JSONObject> entityJSONObjects = _testrayServer.requestGraphQL(
-				"builds", TestrayBuild.FIELD_NAMES, filter, null, 1, 1);
+				"builds", TestrayBuild.FIELD_NAMES, filterString, null, 1, 1);
 
 			if (entityJSONObjects.isEmpty()) {
 				return null;
@@ -314,12 +314,13 @@ public class TestrayRoutine {
 
 		setTestrayServer(testrayServer);
 
-		String filter = JenkinsResultsParserUtil.combine(
+		String filterString = JenkinsResultsParserUtil.combine(
 			"id eq '", matcher.group("routineID"), "'");
 
 		try {
 			Set<JSONObject> entityJSONObjects = testrayServer.requestGraphQL(
-				"routines", TestrayRoutine.FIELD_NAMES, filter, null, 1, 1);
+				"routines", TestrayRoutine.FIELD_NAMES, filterString, null, 1,
+				1);
 
 			if (entityJSONObjects.isEmpty()) {
 				return;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayRun.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayRun.java
@@ -29,20 +29,36 @@ import org.json.JSONObject;
  */
 public class TestrayRun {
 
+	public static final String[] FIELD_NAMES = {
+		"dateCreated", "dateModified", "id", "name"
+	};
+
 	public static String getDefaultRunIDString() {
 		return _properties.getProperty("testray.environment.default[master]");
 	}
 
 	public List<Factor> getFactors() {
-		return factors;
+		return _factors;
 	}
 
 	public long getID() {
+		if (_id != null) {
+			return _id;
+		}
+
 		if (_jsonObject == null) {
+			_id = _testrayBuild.getTestrayRunID(this);
+
+			if (_id != null) {
+				return _id;
+			}
+
 			return 0;
 		}
 
-		return _jsonObject.getLong("id");
+		_id = _jsonObject.optLong("id");
+
+		return _id;
 	}
 
 	public String getRunIDString() {
@@ -71,6 +87,10 @@ public class TestrayRun {
 		}
 
 		return testrayBuild.getTestrayServer();
+	}
+
+	public void setID(long id) {
+		_id = id;
 	}
 
 	public static class Factor {
@@ -203,7 +223,7 @@ public class TestrayRun {
 	protected void initializeFactorsByAxisTestClassGroup(
 		AxisTestClassGroup axisTestClassGroup) {
 
-		factors = new ArrayList<>();
+		_factors = new ArrayList<>();
 
 		if (axisTestClassGroup == null) {
 			return;
@@ -242,7 +262,7 @@ public class TestrayRun {
 				continue;
 			}
 
-			factors.add(new Factor(factoryName, factoryValue));
+			_factors.add(new Factor(factoryName, factoryValue));
 		}
 
 		BatchTestClassGroup batchTestClassGroup =
@@ -255,7 +275,7 @@ public class TestrayRun {
 	protected void initializeFactorsByBatchName(
 		String batchName, String testSuiteName) {
 
-		factors = new ArrayList<>();
+		_factors = new ArrayList<>();
 
 		if (JenkinsResultsParserUtil.isNullOrEmpty(batchName)) {
 			return;
@@ -275,14 +295,14 @@ public class TestrayRun {
 				continue;
 			}
 
-			factors.add(new Factor(factoryName, factoryValue));
+			_factors.add(new Factor(factoryName, factoryValue));
 		}
 
 		_addSearchEngineFactor(batchName, testSuiteName);
 	}
 
 	protected void initializeFactorsByJSONObject(JSONObject jsonObject) {
-		factors = new ArrayList<>();
+		_factors = new ArrayList<>();
 
 		if (jsonObject == null) {
 			return;
@@ -307,15 +327,13 @@ public class TestrayRun {
 					String factorName = _getFactorName(
 						factorValueMatcher.group("nameKey"));
 
-					factors.add(new Factor(factorName, factorValue));
+					_factors.add(new Factor(factorName, factorValue));
 
 					break;
 				}
 			}
 		}
 	}
-
-	protected List<Factor> factors;
 
 	private void _addSearchEngineFactor(
 		String batchName, String testSuiteName) {
@@ -333,7 +351,7 @@ public class TestrayRun {
 			return;
 		}
 
-		factors.add(
+		_factors.add(
 			new Factor(searchEngineFactorName, searchEngineFactorValue));
 	}
 
@@ -506,6 +524,8 @@ public class TestrayRun {
 			"\\[(?<nameKey>[^\\]]+)\\](\\[(?<valueKey>[^\\]]+)\\])?");
 	private static final Properties _properties = new Properties();
 
+	private List<Factor> _factors;
+	private Long _id;
 	private final JSONObject _jsonObject;
 	private final TestrayBuild _testrayBuild;
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayServer.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayServer.java
@@ -143,7 +143,7 @@ public class TestrayServer {
 				throw new RuntimeException(ioException);
 			}
 
-			return _testrayCaseTypesID.get(testrayCaseTypeID);
+			return testrayCaseType;
 		}
 	}
 
@@ -181,7 +181,7 @@ public class TestrayServer {
 				throw new RuntimeException(ioException);
 			}
 
-			return _testrayCaseTypesName.get(testrayCaseTypeName);
+			return testrayCaseType;
 		}
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayServer.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayServer.java
@@ -150,11 +150,11 @@ public class TestrayServer {
 	public TestrayCaseType getTestrayCaseTypeByName(
 		String testrayCaseTypeName) {
 
-		synchronized (_testrayCaseTypesID) {
-			if (JenkinsResultsParserUtil.isNullOrEmpty(testrayCaseTypeName)) {
-				return null;
-			}
+		if (JenkinsResultsParserUtil.isNullOrEmpty(testrayCaseTypeName)) {
+			return null;
+		}
 
+		synchronized (_testrayCaseTypesID) {
 			TestrayCaseType testrayCaseType = _testrayCaseTypesName.get(
 				testrayCaseTypeName);
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayServer.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayServer.java
@@ -151,6 +151,10 @@ public class TestrayServer {
 		String testrayCaseTypeName) {
 
 		synchronized (_testrayCaseTypesID) {
+			if (JenkinsResultsParserUtil.isNullOrEmpty(testrayCaseTypeName)) {
+				return null;
+			}
+
 			TestrayCaseType testrayCaseType = _testrayCaseTypesName.get(
 				testrayCaseTypeName);
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayServer.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayServer.java
@@ -112,71 +112,77 @@ public class TestrayServer {
 	}
 
 	public TestrayCaseType getTestrayCaseTypeByID(long testrayCaseTypeID) {
-		TestrayCaseType testrayCaseType = _testrayCaseTypesID.get(
-			testrayCaseTypeID);
+		synchronized (_testrayCaseTypesID) {
+			TestrayCaseType testrayCaseType = _testrayCaseTypesID.get(
+				testrayCaseTypeID);
 
-		if (testrayCaseType != null) {
-			return testrayCaseType;
-		}
-
-		try {
-			Set<JSONObject> entityJSONObjects = requestGraphQL(
-				"caseTypes", TestrayCaseType.FIELD_NAMES,
-				"id eq '" + testrayCaseTypeID + "'", null, 1, 1);
-
-			if (entityJSONObjects.isEmpty()) {
-				return null;
+			if (testrayCaseType != null) {
+				return testrayCaseType;
 			}
 
-			Iterator<JSONObject> iterator = entityJSONObjects.iterator();
+			try {
+				Set<JSONObject> entityJSONObjects = requestGraphQL(
+					"caseTypes", TestrayCaseType.FIELD_NAMES,
+					"id eq '" + testrayCaseTypeID + "'", null, 1, 1);
 
-			testrayCaseType = TestrayFactory.newTestrayCaseType(
-				this, iterator.next());
+				if (entityJSONObjects.isEmpty()) {
+					return null;
+				}
 
-			_testrayCaseTypesID.put(testrayCaseType.getID(), testrayCaseType);
-			_testrayCaseTypesName.put(
-				testrayCaseType.getName(), testrayCaseType);
+				Iterator<JSONObject> iterator = entityJSONObjects.iterator();
+
+				testrayCaseType = TestrayFactory.newTestrayCaseType(
+					this, iterator.next());
+
+				_testrayCaseTypesID.put(
+					testrayCaseType.getID(), testrayCaseType);
+				_testrayCaseTypesName.put(
+					testrayCaseType.getName(), testrayCaseType);
+			}
+			catch (IOException ioException) {
+				throw new RuntimeException(ioException);
+			}
+
+			return _testrayCaseTypesID.get(testrayCaseTypeID);
 		}
-		catch (IOException ioException) {
-			throw new RuntimeException(ioException);
-		}
-
-		return _testrayCaseTypesID.get(testrayCaseTypeID);
 	}
 
 	public TestrayCaseType getTestrayCaseTypeByName(
 		String testrayCaseTypeName) {
 
-		TestrayCaseType testrayCaseType = _testrayCaseTypesName.get(
-			testrayCaseTypeName);
+		synchronized (_testrayCaseTypesID) {
+			TestrayCaseType testrayCaseType = _testrayCaseTypesName.get(
+				testrayCaseTypeName);
 
-		if (testrayCaseType != null) {
-			return testrayCaseType;
-		}
-
-		try {
-			Set<JSONObject> entityJSONObjects = requestGraphQL(
-				"caseTypes", TestrayCaseType.FIELD_NAMES,
-				"name eq '" + testrayCaseTypeName + "'", null, 1, 1);
-
-			if (entityJSONObjects.isEmpty()) {
-				return null;
+			if (testrayCaseType != null) {
+				return testrayCaseType;
 			}
 
-			Iterator<JSONObject> iterator = entityJSONObjects.iterator();
+			try {
+				Set<JSONObject> entityJSONObjects = requestGraphQL(
+					"caseTypes", TestrayCaseType.FIELD_NAMES,
+					"name eq '" + testrayCaseTypeName + "'", null, 1, 1);
 
-			testrayCaseType = TestrayFactory.newTestrayCaseType(
-				this, iterator.next());
+				if (entityJSONObjects.isEmpty()) {
+					return null;
+				}
 
-			_testrayCaseTypesID.put(testrayCaseType.getID(), testrayCaseType);
-			_testrayCaseTypesName.put(
-				testrayCaseType.getName(), testrayCaseType);
+				Iterator<JSONObject> iterator = entityJSONObjects.iterator();
+
+				testrayCaseType = TestrayFactory.newTestrayCaseType(
+					this, iterator.next());
+
+				_testrayCaseTypesID.put(
+					testrayCaseType.getID(), testrayCaseType);
+				_testrayCaseTypesName.put(
+					testrayCaseType.getName(), testrayCaseType);
+			}
+			catch (IOException ioException) {
+				throw new RuntimeException(ioException);
+			}
+
+			return _testrayCaseTypesName.get(testrayCaseTypeName);
 		}
-		catch (IOException ioException) {
-			throw new RuntimeException(ioException);
-		}
-
-		return _testrayCaseTypesName.get(testrayCaseTypeName);
 	}
 
 	public TestrayProject getTestrayProjectByID(long projectID) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayServer.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayServer.java
@@ -415,7 +415,7 @@ public class TestrayServer {
 
 	protected Set<JSONObject> requestGraphQL(
 			boolean checkCache, String entityName, String[] entityFields,
-			String filter, String sort, long maxCount, int pageSize)
+			String filterString, String sortString, long maxCount, int pageSize)
 		throws IOException {
 
 		if (maxCount <= 0) {
@@ -448,15 +448,15 @@ public class TestrayServer {
 			sb.append(", pageSize: ");
 			sb.append(pageSize);
 
-			if (!JenkinsResultsParserUtil.isNullOrEmpty(filter)) {
+			if (!JenkinsResultsParserUtil.isNullOrEmpty(filterString)) {
 				sb.append(", filter: \"");
-				sb.append(filter);
+				sb.append(filterString);
 				sb.append("\"");
 			}
 
-			if (!JenkinsResultsParserUtil.isNullOrEmpty(sort)) {
+			if (!JenkinsResultsParserUtil.isNullOrEmpty(sortString)) {
 				sb.append(", sort: \"");
-				sb.append(sort);
+				sb.append(sortString);
 				sb.append("\"");
 			}
 
@@ -528,20 +528,22 @@ public class TestrayServer {
 	}
 
 	protected Set<JSONObject> requestGraphQL(
-			String entityName, String[] entityFields, String filter,
-			String sort)
-		throws IOException {
-
-		return requestGraphQL(entityName, entityFields, filter, sort, 0, 0);
-	}
-
-	protected Set<JSONObject> requestGraphQL(
-			String entityName, String[] entityFields, String filter,
-			String sort, long maxCount, int pageSize)
+			String entityName, String[] entityFields, String filterString,
+			String sortString)
 		throws IOException {
 
 		return requestGraphQL(
-			false, entityName, entityFields, filter, sort, maxCount, pageSize);
+			entityName, entityFields, filterString, sortString, 0, 0);
+	}
+
+	protected Set<JSONObject> requestGraphQL(
+			String entityName, String[] entityFields, String filterString,
+			String sortString, long maxCount, int pageSize)
+		throws IOException {
+
+		return requestGraphQL(
+			false, entityName, entityFields, filterString, sortString, maxCount,
+			pageSize);
 	}
 
 	private void _importCaseResultsToGCP(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-6956

## What Is Being Fixed

The jenkins-results-parser Testray client could not resolve a Testray case or component by name and type, only by ID. Batch build case results had no way to obtain their associated case, component, or run information, and the existing by-name queries were imprecise — matching builds too loosely and re-deriving values that were already available. Repeated lookups also hit the Testray server redundantly, and concurrent access to shared case-type, component, and team state was unguarded.

## How It Is Being Fixed

TestrayProject gains the ability to look up a case by name and type and a component by name, and BatchBuildTestrayCaseResult resolves its case, component, and result URL through these lookups, reusing TestrayRun.getID rather than re-extracting the ID from JSON. Build-by-name queries are made more specific, and TestrayBuild can now surface the TestrayRun IDs it contains. Lookups that previously recursed between getTestrayCase and getTestrayComponent are broken apart and guarded against null builds and null JSON, and null or empty filter values are now rejected outright (with the null check moved outside the synchronized block). The by-name fallback and resolved case type are cached to avoid redundant server round trips and cache-key mismatches, and access to case types, components, and teams is synchronized. The filter variable is renamed to filterString for clarity.

## Why Are There No Tests?

The commits are internal refactors and caching of the existing Testray lookup paths with no behavioral change to the surrounding flow; the code is exercised by the live CI pipeline that consumes jenkins-results-parser.
