### PR TITLE
LRCI-6956 Derive the top level build URL from the build description

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayBuild.java
@@ -7,6 +7,7 @@ package com.liferay.jenkins.results.parser.testray;
 
 import com.liferay.jenkins.results.parser.BuildReportFactory;
 import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+import com.liferay.jenkins.results.parser.MultiPattern;
 import com.liferay.jenkins.results.parser.TopLevelBuildReport;
 
 import java.io.IOException;
@@ -438,18 +439,48 @@ public class TestrayBuild implements Comparable<TestrayBuild> {
 	}
 
 	public URL getTopLevelBuildURL() {
-		Matcher matcher = _getTestrayAttachmentURLMatcher();
+		String topLevelMasterHostname = null;
+		String topLevelJobName = null;
+		String topLevelBuildNumber = null;
 
-		if (matcher == null) {
+		String description = getDescription();
+
+		Matcher descriptionMatcher = null;
+
+		if (!JenkinsResultsParserUtil.isNullOrEmpty(description)) {
+			descriptionMatcher = _descriptionPattern.matches(description);
+		}
+
+		if (descriptionMatcher != null) {
+			topLevelMasterHostname = descriptionMatcher.group(
+				"topLevelMasterHostname");
+			topLevelJobName = descriptionMatcher.group("topLevelJobName");
+			topLevelBuildNumber = descriptionMatcher.group(
+				"topLevelBuildNumber");
+		}
+		else {
+			Matcher testrayAttachmentURLMatcher =
+				_getTestrayAttachmentURLMatcher();
+
+			if (testrayAttachmentURLMatcher != null) {
+				topLevelMasterHostname = testrayAttachmentURLMatcher.group(
+					"topLevelMasterHostname");
+				topLevelJobName = testrayAttachmentURLMatcher.group(
+					"topLevelJobName");
+				topLevelBuildNumber = testrayAttachmentURLMatcher.group(
+					"topLevelBuildNumber");
+			}
+		}
+
+		if (topLevelMasterHostname == null) {
 			return null;
 		}
 
 		try {
 			return new URL(
 				JenkinsResultsParserUtil.combine(
-					"https://", matcher.group("topLevelMasterHostname"),
-					".liferay.com/job/", matcher.group("topLevelJobName"), "/",
-					matcher.group("topLevelBuildNumber"), "/"));
+					"https://", topLevelMasterHostname, ".liferay.com/job/",
+					topLevelJobName, "/", topLevelBuildNumber, "/"));
 		}
 		catch (MalformedURLException malformedURLException) {
 			throw new RuntimeException(malformedURLException);
@@ -617,6 +648,16 @@ public class TestrayBuild implements Comparable<TestrayBuild> {
 		return null;
 	}
 
+	private static final MultiPattern _descriptionPattern = new MultiPattern(
+		JenkinsResultsParserUtil.combine(
+			".*<a href=\"https://(?<topLevelMasterHostname>test-\\d+-\\d+)",
+			"\\.liferay\\.com/userContent/jobs/(?<topLevelJobName>[^/]+)/",
+			"builds/(?<topLevelBuildNumber>\\d+)/jenkins-report\\.html\">",
+			"Jenkins Report</a>.*"),
+		JenkinsResultsParserUtil.combine(
+			".*<a href=\".+/testray-results/\\d{4}-\\d{2}/",
+			"(?<topLevelMasterHostname>test-\\d+-\\d+)/",
+			"(?<topLevelJobName>[^/]+)/(?<topLevelBuildNumber>[^/]+)/.+"));
 	private static final Pattern _portalBranchPattern = Pattern.compile(
 		"Portal Branch: (?<portalBranch>[^;]+);");
 	private static final Pattern _testrayAttachmentURLPattern = Pattern.compile(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayBuild.java
@@ -657,7 +657,8 @@ public class TestrayBuild implements Comparable<TestrayBuild> {
 		JenkinsResultsParserUtil.combine(
 			".*<a href=\".+/testray-results/\\d{4}-\\d{2}/",
 			"(?<topLevelMasterHostname>test-\\d+-\\d+)/",
-			"(?<topLevelJobName>[^/]+)/(?<topLevelBuildNumber>[^/]+)/.+"));
+			"(?<topLevelJobName>[^/]+)/(?<topLevelBuildNumber>\\d+)/",
+			"[^\"]+\">Jenkins Report</a>.*"));
 	private static final Pattern _portalBranchPattern = Pattern.compile(
 		"Portal Branch: (?<portalBranch>[^;]+);");
 	private static final Pattern _testrayAttachmentURLPattern = Pattern.compile(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayBuild.java
@@ -441,33 +441,28 @@ public class TestrayBuild implements Comparable<TestrayBuild> {
 	public URL getTopLevelBuildURL() {
 		String description = getDescription();
 
-		Matcher descriptionMatcher = null;
+		Matcher matcher = null;
 
 		if (!JenkinsResultsParserUtil.isNullOrEmpty(description)) {
-			descriptionMatcher = _descriptionPattern.matches(description);
+			matcher = _descriptionPattern.matches(description);
 		}
 
 		String topLevelBuildNumber = null;
 		String topLevelJobName = null;
 		String topLevelMasterHostname = null;
 
-		if (descriptionMatcher != null) {
-			topLevelBuildNumber = descriptionMatcher.group(
-				"topLevelBuildNumber");
-			topLevelJobName = descriptionMatcher.group("topLevelJobName");
-			topLevelMasterHostname = descriptionMatcher.group(
-				"topLevelMasterHostname");
+		if (matcher != null) {
+			topLevelBuildNumber = matcher.group("topLevelBuildNumber");
+			topLevelJobName = matcher.group("topLevelJobName");
+			topLevelMasterHostname = matcher.group("topLevelMasterHostname");
 		}
 		else {
-			Matcher testrayAttachmentURLMatcher =
-				_getTestrayAttachmentURLMatcher();
+			matcher = _getTestrayAttachmentURLMatcher();
 
-			if (testrayAttachmentURLMatcher != null) {
-				topLevelBuildNumber = testrayAttachmentURLMatcher.group(
-					"topLevelBuildNumber");
-				topLevelJobName = testrayAttachmentURLMatcher.group(
-					"topLevelJobName");
-				topLevelMasterHostname = testrayAttachmentURLMatcher.group(
+			if (matcher != null) {
+				topLevelBuildNumber = matcher.group("topLevelBuildNumber");
+				topLevelJobName = matcher.group("topLevelJobName");
+				topLevelMasterHostname = matcher.group(
 					"topLevelMasterHostname");
 			}
 		}
@@ -480,7 +475,7 @@ public class TestrayBuild implements Comparable<TestrayBuild> {
 			return new URL(
 				JenkinsResultsParserUtil.combine(
 					"https://", topLevelMasterHostname, ".liferay.com/job/",
-					topLevelJobName, "/", topLevelBuildNumber, "/"));
+					topLevelJobName, "/", topLevelBuildNumber));
 		}
 		catch (MalformedURLException malformedURLException) {
 			throw new RuntimeException(malformedURLException);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayBuild.java
@@ -439,10 +439,6 @@ public class TestrayBuild implements Comparable<TestrayBuild> {
 	}
 
 	public URL getTopLevelBuildURL() {
-		String topLevelMasterHostname = null;
-		String topLevelJobName = null;
-		String topLevelBuildNumber = null;
-
 		String description = getDescription();
 
 		Matcher descriptionMatcher = null;
@@ -451,24 +447,28 @@ public class TestrayBuild implements Comparable<TestrayBuild> {
 			descriptionMatcher = _descriptionPattern.matches(description);
 		}
 
+		String topLevelBuildNumber = null;
+		String topLevelJobName = null;
+		String topLevelMasterHostname = null;
+
 		if (descriptionMatcher != null) {
-			topLevelMasterHostname = descriptionMatcher.group(
-				"topLevelMasterHostname");
-			topLevelJobName = descriptionMatcher.group("topLevelJobName");
 			topLevelBuildNumber = descriptionMatcher.group(
 				"topLevelBuildNumber");
+			topLevelJobName = descriptionMatcher.group("topLevelJobName");
+			topLevelMasterHostname = descriptionMatcher.group(
+				"topLevelMasterHostname");
 		}
 		else {
 			Matcher testrayAttachmentURLMatcher =
 				_getTestrayAttachmentURLMatcher();
 
 			if (testrayAttachmentURLMatcher != null) {
-				topLevelMasterHostname = testrayAttachmentURLMatcher.group(
-					"topLevelMasterHostname");
-				topLevelJobName = testrayAttachmentURLMatcher.group(
-					"topLevelJobName");
 				topLevelBuildNumber = testrayAttachmentURLMatcher.group(
 					"topLevelBuildNumber");
+				topLevelJobName = testrayAttachmentURLMatcher.group(
+					"topLevelJobName");
+				topLevelMasterHostname = testrayAttachmentURLMatcher.group(
+					"topLevelMasterHostname");
 			}
 		}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayImporter.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayImporter.java
@@ -43,6 +43,8 @@ import com.liferay.jenkins.results.parser.test.clazz.group.PlaywrightAxisTestCla
 import java.io.File;
 import java.io.IOException;
 
+import java.net.URL;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -386,7 +388,19 @@ public class TestrayImporter {
 		}
 
 		sb.append("<a href=\"");
-		sb.append(_topLevelBuildReport.getJenkinsReportURL());
+
+		URL jenkinsReportTestrayAttachmentURL =
+			_topLevelBuildReport.getTestrayAttachmentURLBySuffix(
+				"jenkins-report.html.gz");
+
+		if (jenkinsReportTestrayAttachmentURL != null) {
+			sb.append(jenkinsReportTestrayAttachmentURL);
+			sb.append("?authuser=0");
+		}
+		else {
+			sb.append(_topLevelBuildReport.getJenkinsReportURL());
+		}
+
 		sb.append("\">Jenkins Report</a>");
 		sb.append("; ");
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayImporter.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayImporter.java
@@ -389,12 +389,12 @@ public class TestrayImporter {
 
 		sb.append("<a href=\"");
 
-		URL jenkinsReportTestrayAttachmentURL =
+		URL testrayAttachmentURL =
 			_topLevelBuildReport.getTestrayAttachmentURLBySuffix(
 				"jenkins-report.html.gz");
 
-		if (jenkinsReportTestrayAttachmentURL != null) {
-			sb.append(jenkinsReportTestrayAttachmentURL);
+		if (testrayAttachmentURL != null) {
+			sb.append(testrayAttachmentURL);
 			sb.append("?authuser=0");
 		}
 		else {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-6956

## What Is Being Fixed

`TestrayBuild.getTopLevelBuildURL()` derived the top level build URL solely
from a Testray attachment URL matcher. That single source did not cover builds
whose top level coordinates are only present in the build description, so the
URL could come back null when the attachment match failed.

## How It Is Being Fixed

`getTopLevelBuildURL()` now reads the build description first, matching it
against a `MultiPattern` anchored to the "Jenkins Report" link to pull
`topLevelMasterHostname`, `topLevelJobName`, and `topLevelBuildNumber`, and
falls back to the existing Testray attachment URL matcher only when the
description yields nothing. The URL assembly is collapsed onto the three
extracted values regardless of source. On the writing side, `TestrayImporter`
now emits the "Jenkins Report" link from the `jenkins-report.html.gz` Testray
attachment URL (with `?authuser=0`) when one exists, falling back to the plain
Jenkins report URL otherwise, so the description the reader half parses is the
link the writer half produces.

## Why Are There No Tests?

`jenkins-results-parser` is CI infrastructure. The description and attachment
URL parsing is exercised against live Testray and Jenkins data, and the module
has no practical unit harness for these network-dependent classes. The change
is verified by running the importer against real builds.

## PR Check

**pr-check: PASS** — tested on `51944cdd0aa3df5b15fc012b8eeea02a6af0e792`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |

Structural Smoke note: `ConfigurationEnvBuilderTest`, `LibraryReferenceTest`, and `ModulesStructureTest` passed. `Log4jConfigUtilTest` (Whip "not fully covered" coverage assertion) and one `SampleSQLBuilderTest` method (`ClassNotFoundException` for `org.springframework.context.ConfigurableApplicationContext`) failed on pre-existing local-checkout baseline issues unrelated to the diff, which touches only `modules/test/jenkins-results-parser`. Java Unit Tests matched the diff but had no parallel-name counterpart for the changed classes and no cheap runnable suite (the module's tests depend on a live `repository.dir`/Jenkins).

<!-- pr-check {"result": "success", "sha": "51944cdd0aa3df5b15fc012b8eeea02a6af0e792"} -->
