### PR TITLE
LRCI-6956 Create Testray case results and pass parent results

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GenerateTestrayCSVUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GenerateTestrayCSVUtil.java
@@ -43,8 +43,8 @@ public class GenerateTestrayCSVUtil {
 		TestrayServer testrayServer = TestrayFactory.newTestrayServer(
 			String.valueOf(testrayServerURL));
 
-		TestrayBuild testrayBuild = testrayServer.getTestrayBuildByID(
-			projectTestrayBuildId);
+		TestrayBuild testrayBuild = TestrayFactory.newTestrayBuild(
+			testrayServer, projectTestrayBuildId);
 
 		System.out.println("Generating Testray CSV.");
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/AntTargetBatchBuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/AntTargetBatchBuildTestrayCaseResult.java
@@ -16,6 +16,9 @@ import com.liferay.jenkins.results.parser.test.clazz.TestClass;
 import com.liferay.jenkins.results.parser.test.clazz.TestClassMethod;
 import com.liferay.jenkins.results.parser.test.clazz.group.AxisTestClassGroup;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -252,6 +255,17 @@ public class AntTargetBatchBuildTestrayCaseResult
 		}
 
 		return _testClassReport;
+	}
+
+	@Override
+	public List<TestrayAttachment> getTestrayAttachments() {
+		List<TestrayAttachment> testrayAttachments = new ArrayList<>();
+
+		testrayAttachments.add(getParentTestrayCaseResultTestrayAttachment());
+
+		testrayAttachments.removeAll(Collections.singleton(null));
+
+		return testrayAttachments;
 	}
 
 	@Override

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/AppServerBundleStandaloneBuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/AppServerBundleStandaloneBuildTestrayCaseResult.java
@@ -57,6 +57,7 @@ public class AppServerBundleStandaloneBuildTestrayCaseResult
 			super.getTestrayAttachments();
 
 		testrayAttachments.add(_getJenkinsConsoleTestrayAttachment());
+		testrayAttachments.add(getParentTestrayCaseResultTestrayAttachment());
 
 		testrayAttachments.removeAll(Collections.singleton(null));
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BaseStandaloneBuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BaseStandaloneBuildTestrayCaseResult.java
@@ -16,7 +16,6 @@ import java.io.File;
 import java.io.IOException;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -89,21 +88,6 @@ public abstract class BaseStandaloneBuildTestrayCaseResult
 		catch (IOException ioException) {
 			throw new RuntimeException(ioException);
 		}
-	}
-
-	@Override
-	public List<TestrayAttachment> getTestrayAttachments() {
-		List<TestrayAttachment> testrayAttachments = new ArrayList<>();
-
-		testrayAttachments.add(getTopLevelBuildDatabaseTestrayAttachment());
-		testrayAttachments.add(getTopLevelBuildReportTestrayAttachment());
-		testrayAttachments.add(getTopLevelJenkinsConsoleTestrayAttachment());
-		testrayAttachments.add(getTopLevelJenkinsReportTestrayAttachment());
-		testrayAttachments.add(getTopLevelJobSummaryTestrayAttachment());
-
-		testrayAttachments.removeAll(Collections.singleton(null));
-
-		return testrayAttachments;
 	}
 
 	@Override

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BaseTestrayAttachment.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BaseTestrayAttachment.java
@@ -13,10 +13,27 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 
+import org.json.JSONObject;
+
 /**
  * @author Michael Hashimoto
  */
 public abstract class BaseTestrayAttachment implements TestrayAttachment {
+
+	@Override
+	public JSONObject getJSONObject() {
+		JSONObject jsonObject = new JSONObject();
+
+		jsonObject.put(
+			"name", getName()
+		).put(
+			"url", String.valueOf(getURL())
+		).put(
+			"value", getKey()
+		);
+
+		return jsonObject;
+	}
 
 	@Override
 	public String getKey() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BatchBuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BatchBuildTestrayCaseResult.java
@@ -19,6 +19,9 @@ import com.liferay.jenkins.results.parser.job.property.JobPropertyFactory;
 import com.liferay.jenkins.results.parser.test.clazz.TestClass;
 import com.liferay.jenkins.results.parser.test.clazz.TestClassMethod;
 import com.liferay.jenkins.results.parser.test.clazz.group.AxisTestClassGroup;
+import com.liferay.jenkins.results.parser.test.clazz.group.FunctionalAxisTestClassGroup;
+import com.liferay.jenkins.results.parser.test.clazz.group.JUnitAxisTestClassGroup;
+import com.liferay.jenkins.results.parser.test.clazz.group.PlaywrightAxisTestClassGroup;
 
 import java.io.File;
 import java.io.IOException;
@@ -250,12 +253,20 @@ public class BatchBuildTestrayCaseResult
 
 		testrayAttachments.add(_getGradlePluginsAttachment());
 		testrayAttachments.add(_getJenkinsConsoleTestrayAttachment());
-		testrayAttachments.add(getTopLevelBuildDatabaseTestrayAttachment());
-		testrayAttachments.add(getTopLevelBuildReportTestrayAttachment());
-		testrayAttachments.add(getTopLevelJenkinsConsoleTestrayAttachment());
-		testrayAttachments.add(getTopLevelJenkinsReportTestrayAttachment());
-		testrayAttachments.add(getTopLevelJobSummaryTestrayAttachment());
+		testrayAttachments.add(getParentTestrayCaseResultTestrayAttachment());
 		testrayAttachments.add(_getWarningsTestrayAttachment());
+
+		AxisTestClassGroup axisTestClassGroup = getAxisTestClassGroup();
+
+		if (axisTestClassGroup instanceof FunctionalAxisTestClassGroup ||
+			axisTestClassGroup instanceof JUnitAxisTestClassGroup) {
+
+			testrayAttachments.addAll(getLiferayLogTestrayAttachments());
+			testrayAttachments.addAll(getLiferayOSGiLogTestrayAttachments());
+		}
+		else if (axisTestClassGroup instanceof PlaywrightAxisTestClassGroup) {
+			testrayAttachments.addAll(getLiferayLogTestrayAttachments());
+		}
 
 		testrayAttachments.removeAll(Collections.singleton(null));
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BatchBuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BatchBuildTestrayCaseResult.java
@@ -263,46 +263,6 @@ public class BatchBuildTestrayCaseResult
 	}
 
 	@Override
-	public TestrayCase getTestrayCase() {
-		TestrayCase testrayCase = super.getTestrayCase();
-
-		if (testrayCase != null) {
-			return testrayCase;
-		}
-
-		String name = getName();
-
-		if (JenkinsResultsParserUtil.isNullOrEmpty(name)) {
-			return null;
-		}
-
-		String type = getType();
-
-		if (JenkinsResultsParserUtil.isNullOrEmpty(type)) {
-			return null;
-		}
-
-		TestrayServer testrayServer = getTestrayServer();
-
-		TestrayCaseType testrayCaseType =
-			testrayServer.getTestrayCaseTypeByName(type);
-
-		if (testrayCaseType == null) {
-			return null;
-		}
-
-		TestrayBuild testrayBuild = getTestrayBuild();
-
-		TestrayProject testrayProject = testrayBuild.getTestrayProject();
-
-		testrayCase = testrayProject.getTestrayCase(name, testrayCaseType);
-
-		setTestrayCase(testrayCase);
-
-		return testrayCase;
-	}
-
-	@Override
 	public TestrayComponent getTestrayComponent() {
 		TestrayComponent testrayComponent = super.getTestrayComponent();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BuildTestrayCaseResult.java
@@ -80,6 +80,26 @@ public abstract class BuildTestrayCaseResult extends TestrayCaseResult {
 		return _buildReport;
 	}
 
+	protected TestrayAttachment getParentTestrayCaseResultTestrayAttachment() {
+		TestrayCaseResult parentTestrayCaseResult =
+			getParentTestrayCaseResult();
+
+		if (parentTestrayCaseResult == null) {
+			return null;
+		}
+
+		String testrayCaseResultURL = String.valueOf(
+			parentTestrayCaseResult.getTestrayCaseResultURL());
+
+		TestrayServer testrayServer = getTestrayServer();
+
+		return new DefaultTestrayAttachment(
+			this, parentTestrayCaseResult.getName(),
+			testrayCaseResultURL.replace(
+				String.valueOf(testrayServer.getURL()), ""),
+			parentTestrayCaseResult.getTestrayCaseResultURL());
+	}
+
 	protected TestrayAttachment getTestrayAttachment(
 		BuildReport buildReport, String name, String key) {
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/FunctionalBatchBuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/FunctionalBatchBuildTestrayCaseResult.java
@@ -105,12 +105,9 @@ public class FunctionalBatchBuildTestrayCaseResult
 
 	@Override
 	public List<TestrayAttachment> getTestrayAttachments() {
-		List<TestrayAttachment> testrayAttachments =
-			super.getTestrayAttachments();
+		List<TestrayAttachment> testrayAttachments = new ArrayList<>();
 
-		testrayAttachments.addAll(getLiferayLogTestrayAttachments());
-		testrayAttachments.addAll(getLiferayOSGiLogTestrayAttachments());
-
+		testrayAttachments.add(getParentTestrayCaseResultTestrayAttachment());
 		testrayAttachments.add(_getPoshiConsoleTestrayAttachment());
 		testrayAttachments.add(_getPoshiReportTestrayAttachment());
 		testrayAttachments.add(_getPoshiSummaryTestrayAttachment());

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/JSUnitBatchBuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/JSUnitBatchBuildTestrayCaseResult.java
@@ -17,6 +17,7 @@ import com.liferay.jenkins.results.parser.test.clazz.TestClassMethod;
 import com.liferay.jenkins.results.parser.test.clazz.group.AxisTestClassGroup;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -178,6 +179,17 @@ public class JSUnitBatchBuildTestrayCaseResult
 		}
 
 		return Status.PASSED;
+	}
+
+	@Override
+	public List<TestrayAttachment> getTestrayAttachments() {
+		List<TestrayAttachment> testrayAttachments = new ArrayList<>();
+
+		testrayAttachments.add(getParentTestrayCaseResultTestrayAttachment());
+
+		testrayAttachments.removeAll(Collections.singleton(null));
+
+		return testrayAttachments;
 	}
 
 	@Override

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/JUnitBatchBuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/JUnitBatchBuildTestrayCaseResult.java
@@ -292,12 +292,10 @@ public class JUnitBatchBuildTestrayCaseResult
 
 	@Override
 	public List<TestrayAttachment> getTestrayAttachments() {
-		List<TestrayAttachment> testrayAttachments =
-			super.getTestrayAttachments();
+		List<TestrayAttachment> testrayAttachments = new ArrayList<>();
 
 		testrayAttachments.add(getFailureMessagesTestrayAttachment());
-		testrayAttachments.addAll(getLiferayLogTestrayAttachments());
-		testrayAttachments.addAll(getLiferayOSGiLogTestrayAttachments());
+		testrayAttachments.add(getParentTestrayCaseResultTestrayAttachment());
 
 		testrayAttachments.removeAll(Collections.singleton(null));
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/ModulesBatchBuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/ModulesBatchBuildTestrayCaseResult.java
@@ -16,6 +16,9 @@ import com.liferay.jenkins.results.parser.test.clazz.TestClass;
 import com.liferay.jenkins.results.parser.test.clazz.TestClassMethod;
 import com.liferay.jenkins.results.parser.test.clazz.group.AxisTestClassGroup;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -197,6 +200,17 @@ public class ModulesBatchBuildTestrayCaseResult
 		}
 
 		return _testClassReport;
+	}
+
+	@Override
+	public List<TestrayAttachment> getTestrayAttachments() {
+		List<TestrayAttachment> testrayAttachments = new ArrayList<>();
+
+		testrayAttachments.add(getParentTestrayCaseResultTestrayAttachment());
+
+		testrayAttachments.removeAll(Collections.singleton(null));
+
+		return testrayAttachments;
 	}
 
 	@Override

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/PlaywrightBatchBuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/PlaywrightBatchBuildTestrayCaseResult.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -177,11 +178,9 @@ public class PlaywrightBatchBuildTestrayCaseResult
 
 	@Override
 	public List<TestrayAttachment> getTestrayAttachments() {
-		List<TestrayAttachment> testrayAttachments =
-			super.getTestrayAttachments();
+		List<TestrayAttachment> testrayAttachments = new ArrayList<>();
 
-		testrayAttachments.addAll(getLiferayLogTestrayAttachments());
-
+		testrayAttachments.add(getParentTestrayCaseResultTestrayAttachment());
 		testrayAttachments.add(getPlaywrightReportTestrayAttachment());
 		testrayAttachments.add(getPlaywrightTraceViewerTestrayAttachment());
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayAttachment.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayAttachment.java
@@ -7,10 +7,14 @@ package com.liferay.jenkins.results.parser.testray;
 
 import java.net.URL;
 
+import org.json.JSONObject;
+
 /**
  * @author Michael Hashimoto
  */
 public interface TestrayAttachment {
+
+	public JSONObject getJSONObject();
 
 	public String getKey();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayBuild.java
@@ -56,6 +56,21 @@ public class TestrayBuild implements Comparable<TestrayBuild> {
 		"dateModified", "dueStatus { key name }", "errors", "id", "startDate"
 	};
 
+	public static long getID(URL testrayBuildURL) {
+		if (testrayBuildURL == null) {
+			return 0;
+		}
+
+		Matcher matcher = _testrayBuildURLPattern.matcher(
+			String.valueOf(testrayBuildURL));
+
+		if (!matcher.find()) {
+			return 0;
+		}
+
+		return Long.parseLong(matcher.group("buildID"));
+	}
+
 	public int compareTo(TestrayBuild testrayBuild) {
 		if (testrayBuild == null) {
 			throw new NullPointerException("Testray build is null");
@@ -478,9 +493,73 @@ public class TestrayBuild implements Comparable<TestrayBuild> {
 		_jsonObject = jsonObject;
 	}
 
-	protected TestrayBuild(TestrayServer testrayServer, JSONObject jsonObject) {
+	protected TestrayBuild(TestrayRoutine testrayRoutine, long id) {
+		_testrayRoutine = testrayRoutine;
+
+		_testrayServer = testrayRoutine.getTestrayServer();
+
+		try {
+			String filterString = JenkinsResultsParserUtil.combine(
+				"id eq '", String.valueOf(id),
+				"' and r_routineToBuilds_c_routineId eq '",
+				String.valueOf(testrayRoutine.getID()), "'");
+
+			Set<JSONObject> entityJSONObjects = _testrayServer.requestGraphQL(
+				"builds", FIELD_NAMES, filterString, null, 1, 1);
+
+			if (entityJSONObjects.isEmpty()) {
+				throw new RuntimeException("Build ID not found: " + id);
+			}
+
+			Iterator<JSONObject> iterator = entityJSONObjects.iterator();
+
+			JSONObject entityJSONObject = iterator.next();
+
+			JSONObject projectJSONObject = entityJSONObject.getJSONObject(
+				"projectToBuilds");
+
+			_testrayProject = _testrayServer.getTestrayProjectByID(
+				projectJSONObject.getLong("id"));
+
+			_jsonObject = entityJSONObject;
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(ioException);
+		}
+	}
+
+	protected TestrayBuild(TestrayServer testrayServer, long id) {
 		_testrayServer = testrayServer;
-		_jsonObject = jsonObject;
+
+		try {
+			Set<JSONObject> entityJSONObjects = testrayServer.requestGraphQL(
+				"builds", FIELD_NAMES, "id eq '" + id + "'", null, 1, 1);
+
+			if (entityJSONObjects.isEmpty()) {
+				throw new RuntimeException("Build ID not found: " + id);
+			}
+
+			Iterator<JSONObject> iterator = entityJSONObjects.iterator();
+
+			JSONObject entityJSONObject = iterator.next();
+
+			JSONObject projectJSONObject = entityJSONObject.getJSONObject(
+				"projectToBuilds");
+
+			_testrayProject = testrayServer.getTestrayProjectByID(
+				projectJSONObject.getLong("id"));
+
+			JSONObject routineJSONObject = entityJSONObject.getJSONObject(
+				"routineToBuilds");
+
+			_testrayRoutine = _testrayProject.getTestrayRoutineByID(
+				routineJSONObject.getLong("id"));
+
+			_jsonObject = entityJSONObject;
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(ioException);
+		}
 	}
 
 	protected TestrayBuild(URL url) {
@@ -601,7 +680,7 @@ public class TestrayBuild implements Comparable<TestrayBuild> {
 	private Matcher _testrayAttachmentURLMatcher;
 	private TestrayProductVersion _testrayProductVersion;
 	private TestrayProject _testrayProject;
-	private TestrayRoutine _testrayRoutine;
+	private final TestrayRoutine _testrayRoutine;
 	private List<TestrayRun> _testrayRuns;
 	private final TestrayServer _testrayServer;
 	private TopLevelBuildReport _topLevelBuildReport;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayBuild.java
@@ -493,73 +493,21 @@ public class TestrayBuild implements Comparable<TestrayBuild> {
 		_jsonObject = jsonObject;
 	}
 
-	protected TestrayBuild(TestrayRoutine testrayRoutine, long id) {
-		_testrayRoutine = testrayRoutine;
-
-		_testrayServer = testrayRoutine.getTestrayServer();
-
-		try {
-			String filterString = JenkinsResultsParserUtil.combine(
-				"id eq '", String.valueOf(id),
-				"' and r_routineToBuilds_c_routineId eq '",
-				String.valueOf(testrayRoutine.getID()), "'");
-
-			Set<JSONObject> entityJSONObjects = _testrayServer.requestGraphQL(
-				"builds", FIELD_NAMES, filterString, null, 1, 1);
-
-			if (entityJSONObjects.isEmpty()) {
-				throw new RuntimeException("Build ID not found: " + id);
-			}
-
-			Iterator<JSONObject> iterator = entityJSONObjects.iterator();
-
-			JSONObject entityJSONObject = iterator.next();
-
-			JSONObject projectJSONObject = entityJSONObject.getJSONObject(
-				"projectToBuilds");
-
-			_testrayProject = _testrayServer.getTestrayProjectByID(
-				projectJSONObject.getLong("id"));
-
-			_jsonObject = entityJSONObject;
-		}
-		catch (IOException ioException) {
-			throw new RuntimeException(ioException);
-		}
-	}
-
-	protected TestrayBuild(TestrayServer testrayServer, long id) {
+	protected TestrayBuild(TestrayServer testrayServer, JSONObject jsonObject) {
 		_testrayServer = testrayServer;
+		_jsonObject = jsonObject;
 
-		try {
-			Set<JSONObject> entityJSONObjects = testrayServer.requestGraphQL(
-				"builds", FIELD_NAMES, "id eq '" + id + "'", null, 1, 1);
+		JSONObject projectJSONObject = jsonObject.getJSONObject(
+			"projectToBuilds");
 
-			if (entityJSONObjects.isEmpty()) {
-				throw new RuntimeException("Build ID not found: " + id);
-			}
+		_testrayProject = testrayServer.getTestrayProjectByID(
+			projectJSONObject.getLong("id"));
 
-			Iterator<JSONObject> iterator = entityJSONObjects.iterator();
+		JSONObject routineJSONObject = jsonObject.getJSONObject(
+			"routineToBuilds");
 
-			JSONObject entityJSONObject = iterator.next();
-
-			JSONObject projectJSONObject = entityJSONObject.getJSONObject(
-				"projectToBuilds");
-
-			_testrayProject = testrayServer.getTestrayProjectByID(
-				projectJSONObject.getLong("id"));
-
-			JSONObject routineJSONObject = entityJSONObject.getJSONObject(
-				"routineToBuilds");
-
-			_testrayRoutine = _testrayProject.getTestrayRoutineByID(
-				routineJSONObject.getLong("id"));
-
-			_jsonObject = entityJSONObject;
-		}
-		catch (IOException ioException) {
-			throw new RuntimeException(ioException);
-		}
+		_testrayRoutine = _testrayProject.getTestrayRoutineByID(
+			routineJSONObject.getLong("id"));
 	}
 
 	protected TestrayBuild(URL url) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCaseResult.java
@@ -6,6 +6,7 @@
 package com.liferay.jenkins.results.parser.testray;
 
 import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+import com.liferay.jenkins.results.parser.Retryable;
 
 import java.io.IOException;
 
@@ -289,7 +290,15 @@ public class TestrayCaseResult {
 			return _testrayCaseResultURL;
 		}
 
-		_testrayCaseResultURL = _fetchTestrayCaseResultURL();
+		URL cachedTestrayCaseResultURL = _fetchTestrayCaseResultURL();
+
+		if (cachedTestrayCaseResultURL != null) {
+			_testrayCaseResultURL = cachedTestrayCaseResultURL;
+
+			return _testrayCaseResultURL;
+		}
+
+		_testrayCaseResultURL = _createTestrayCaseResultURL();
 
 		return _testrayCaseResultURL;
 	}
@@ -592,6 +601,115 @@ public class TestrayCaseResult {
 	}
 
 	protected Map<String, TestrayAttachment> testrayAttachments;
+
+	private synchronized URL _createTestrayCaseResultURL() {
+		final long start = JenkinsResultsParserUtil.getCurrentTimeMillis();
+
+		final JSONObject requestJSONObject = new JSONObject();
+
+		JSONArray testrayAttachmentsJSONArray = new JSONArray();
+
+		for (TestrayAttachment testrayAttachment : getTestrayAttachments()) {
+			testrayAttachmentsJSONArray.put(testrayAttachment.getJSONObject());
+		}
+
+		if (!testrayAttachmentsJSONArray.isEmpty()) {
+			requestJSONObject.put(
+				"attachments", String.valueOf(testrayAttachmentsJSONArray));
+		}
+
+		Status status = getStatus();
+
+		if (status != null) {
+			requestJSONObject.put("dueStatus", status.toString());
+		}
+
+		long duration = getDuration();
+
+		if (duration > 0) {
+			requestJSONObject.put("duration", duration);
+		}
+
+		String errors = getErrors();
+
+		if (!JenkinsResultsParserUtil.isNullOrEmpty(errors)) {
+			requestJSONObject.put("errors", errors);
+		}
+
+		final TestrayBuild testrayBuild = getTestrayBuild();
+
+		if (testrayBuild != null) {
+			requestJSONObject.put(
+				"r_buildToCaseResult_c_buildId", testrayBuild.getID());
+		}
+
+		TestrayCase testrayCase = getTestrayCase();
+
+		if (testrayCase != null) {
+			requestJSONObject.put(
+				"r_caseToCaseResult_c_caseId", testrayCase.getID());
+		}
+
+		TestrayComponent testrayComponent = getTestrayComponent();
+
+		if (testrayComponent != null) {
+			requestJSONObject.put(
+				"r_componentToCaseResult_c_componentId",
+				testrayComponent.getID());
+		}
+
+		if (_testrayRun != null) {
+			requestJSONObject.put(
+				"r_runToCaseResult_c_runId", _testrayRun.getID());
+		}
+
+		TestrayTeam testrayTeam = getTestrayTeam();
+
+		if (testrayTeam != null) {
+			requestJSONObject.put(
+				"r_teamToCaseResult_c_teamId", testrayTeam.getID());
+		}
+
+		Retryable<URL> retryable = new Retryable<URL>(true, 3, 5, true) {
+
+			@Override
+			public URL execute() {
+				URL cachedTestrayCaseResultURL = _fetchTestrayCaseResultURL();
+
+				if (cachedTestrayCaseResultURL != null) {
+					return cachedTestrayCaseResultURL;
+				}
+
+				try {
+					JSONObject responseJSONObject = new JSONObject(
+						_testrayServer.requestPost(
+							"/o/c/caseresults", requestJSONObject.toString()));
+
+					URL testrayCaseResultURL = new URL(
+						testrayBuild.getURL() + "/case-result/" +
+							responseJSONObject.getLong("id"));
+
+					long end = JenkinsResultsParserUtil.getCurrentTimeMillis();
+
+					System.out.println(
+						JenkinsResultsParserUtil.combine(
+							"Testray Case Result '", getName(), "' ",
+							String.valueOf(testrayCaseResultURL),
+							" created in ",
+							JenkinsResultsParserUtil.toDurationString(
+								end - start)));
+
+					return testrayCaseResultURL;
+				}
+				catch (IOException ioException) {
+					throw new RuntimeException(ioException);
+				}
+			}
+
+		};
+
+		return retryable.executeWithRetries();
+	}
 
 	private URL _fetchTestrayCaseResultURL() {
 		TestrayBuild testrayBuild = getTestrayBuild();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCaseResult.java
@@ -139,6 +139,10 @@ public class TestrayCaseResult {
 		return testrayCase.getName();
 	}
 
+	public TestrayCaseResult getParentTestrayCaseResult() {
+		return _parentTestrayCaseResult;
+	}
+
 	public String getPortalSHA() {
 		TestrayBuild testrayBuild = getTestrayBuild();
 
@@ -394,6 +398,12 @@ public class TestrayCaseResult {
 
 	public String[] getWarnings() {
 		return null;
+	}
+
+	public void setParentTestrayCaseResult(
+		TestrayCaseResult parentTestrayCaseResult) {
+
+		_parentTestrayCaseResult = parentTestrayCaseResult;
 	}
 
 	public void setTestrayCase(TestrayCase testrayCase) {
@@ -684,6 +694,7 @@ public class TestrayCaseResult {
 
 	private ErrorType _errorType;
 	private final JSONObject _jsonObject;
+	private TestrayCaseResult _parentTestrayCaseResult;
 	private TestrayBuild _testrayBuild;
 	private TestrayCase _testrayCase;
 	private boolean _testrayCaseCached;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCaseResult.java
@@ -233,7 +233,7 @@ public class TestrayCaseResult {
 			}
 
 			if (_testrayCase == null) {
-				_testrayCase = getCachedTestrayCase();
+				_testrayCase = _fetchTestrayCase();
 			}
 
 			return _testrayCase;
@@ -523,38 +523,6 @@ public class TestrayCaseResult {
 		}
 	}
 
-	protected TestrayCase getCachedTestrayCase() {
-		String name = getName();
-
-		if (JenkinsResultsParserUtil.isNullOrEmpty(name)) {
-			return null;
-		}
-
-		String type = getType();
-
-		if (JenkinsResultsParserUtil.isNullOrEmpty(type)) {
-			return null;
-		}
-
-		TestrayServer testrayServer = getTestrayServer();
-
-		TestrayCaseType testrayCaseType =
-			testrayServer.getTestrayCaseTypeByName(type);
-
-		if (testrayCaseType == null) {
-			return null;
-		}
-
-		TestrayProject testrayProject = getTestrayProject();
-
-		if (testrayProject == null) {
-			return null;
-		}
-
-		return TestrayFactory.newTestrayCase(
-			testrayProject, name, testrayCaseType);
-	}
-
 	protected synchronized void initTestrayAttachments() {
 		if (testrayAttachments != null) {
 			return;
@@ -713,6 +681,38 @@ public class TestrayCaseResult {
 		};
 
 		return retryable.executeWithRetries();
+	}
+
+	private TestrayCase _fetchTestrayCase() {
+		String name = getName();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(name)) {
+			return null;
+		}
+
+		String type = getType();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(type)) {
+			return null;
+		}
+
+		TestrayServer testrayServer = getTestrayServer();
+
+		TestrayCaseType testrayCaseType =
+			testrayServer.getTestrayCaseTypeByName(type);
+
+		if (testrayCaseType == null) {
+			return null;
+		}
+
+		TestrayProject testrayProject = getTestrayProject();
+
+		if (testrayProject == null) {
+			return null;
+		}
+
+		return TestrayFactory.newTestrayCase(
+			testrayProject, name, testrayCaseType);
 	}
 
 	private URL _fetchTestrayCaseResultURL() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCaseResult.java
@@ -196,8 +196,8 @@ public class TestrayCaseResult {
 			"buildToCaseResult");
 
 		if (buildJSONObject != null) {
-			_testrayBuild = _testrayServer.getTestrayBuildByID(
-				buildJSONObject.getLong("id"));
+			_testrayBuild = TestrayFactory.newTestrayBuild(
+				_testrayServer, buildJSONObject.getLong("id"));
 		}
 
 		return _testrayBuild;
@@ -225,6 +225,10 @@ public class TestrayCaseResult {
 					_testrayCase = TestrayFactory.newTestrayCase(
 						testrayBuild.getTestrayProject(), caseJSONObject);
 				}
+			}
+
+			if (_testrayCase == null) {
+				_testrayCase = getCachedTestrayCase();
 			}
 
 			return _testrayCase;
@@ -276,7 +280,7 @@ public class TestrayCaseResult {
 		return testrayCaseResults;
 	}
 
-	public URL getTestrayCaseResultURL() {
+	public synchronized URL getTestrayCaseResultURL() {
 		if (_testrayCaseResultURL != null) {
 			return _testrayCaseResultURL;
 		}
@@ -498,6 +502,38 @@ public class TestrayCaseResult {
 			propertyElement.addAttribute("name", propertyName);
 			propertyElement.addAttribute("value", propertyValue);
 		}
+	}
+
+	protected TestrayCase getCachedTestrayCase() {
+		String name = getName();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(name)) {
+			return null;
+		}
+
+		String type = getType();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(type)) {
+			return null;
+		}
+
+		TestrayServer testrayServer = getTestrayServer();
+
+		TestrayCaseType testrayCaseType =
+			testrayServer.getTestrayCaseTypeByName(type);
+
+		if (testrayCaseType == null) {
+			return null;
+		}
+
+		TestrayProject testrayProject = getTestrayProject();
+
+		if (testrayProject == null) {
+			return null;
+		}
+
+		return TestrayFactory.newTestrayCase(
+			testrayProject, name, testrayCaseType);
 	}
 
 	protected synchronized void initTestrayAttachments() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCaseResult.java
@@ -603,6 +603,18 @@ public class TestrayCaseResult {
 	protected Map<String, TestrayAttachment> testrayAttachments;
 
 	private synchronized URL _createTestrayCaseResultURL() {
+		final TestrayBuild testrayBuild = getTestrayBuild();
+
+		if (testrayBuild == null) {
+			return null;
+		}
+
+		TestrayCase testrayCase = getTestrayCase();
+
+		if (testrayCase == null) {
+			return null;
+		}
+
 		final long start = JenkinsResultsParserUtil.getCurrentTimeMillis();
 
 		final JSONObject requestJSONObject = new JSONObject();
@@ -636,19 +648,11 @@ public class TestrayCaseResult {
 			requestJSONObject.put("errors", errors);
 		}
 
-		final TestrayBuild testrayBuild = getTestrayBuild();
-
-		if (testrayBuild != null) {
-			requestJSONObject.put(
-				"r_buildToCaseResult_c_buildId", testrayBuild.getID());
-		}
-
-		TestrayCase testrayCase = getTestrayCase();
-
-		if (testrayCase != null) {
-			requestJSONObject.put(
-				"r_caseToCaseResult_c_caseId", testrayCase.getID());
-		}
+		requestJSONObject.put(
+			"r_buildToCaseResult_c_buildId", testrayBuild.getID()
+		).put(
+			"r_caseToCaseResult_c_caseId", testrayCase.getID()
+		);
 
 		TestrayComponent testrayComponent = getTestrayComponent();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayFactor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayFactor.java
@@ -24,13 +24,13 @@ public interface TestrayFactor {
 		"factorOptionToFactors"
 	};
 
-	public BaseTestrayFactor.Category getCategory();
+	public Category getCategory();
 
 	public Long getID();
 
 	public JSONObject getJSONObject();
 
-	public BaseTestrayFactor.Option getOption();
+	public Option getOption();
 
 	public TestrayServer getTestrayServer();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayFactory.java
@@ -326,7 +326,15 @@ public class TestrayFactory {
 			"r_projectToCases_c_projectId eq '",
 			String.valueOf(testrayProject.getID()), "'");
 
-		final TestrayServer testrayServer = testrayProject.getTestrayServer();
+		final JSONObject requestJSONObject = new JSONObject();
+
+		requestJSONObject.put(
+			"name", name
+		).put(
+			"r_caseTypeToCases_c_caseTypeId", testrayCaseType.getID()
+		).put(
+			"r_projectToCases_c_projectId", testrayProject.getID()
+		);
 
 		Retryable<TestrayCase> retryable = new Retryable<TestrayCase>(
 			true, 3, 5, true) {
@@ -334,6 +342,9 @@ public class TestrayFactory {
 			@Override
 			public TestrayCase execute() {
 				try {
+					TestrayServer testrayServer =
+						testrayProject.getTestrayServer();
+
 					Set<JSONObject> entityJSONObjects =
 						testrayServer.requestGraphQL(
 							"cases", TestrayCase.FIELD_NAMES, filterString,
@@ -344,7 +355,24 @@ public class TestrayFactory {
 							testrayProject, entityJSONObject);
 					}
 
-					return null;
+					long start =
+						JenkinsResultsParserUtil.getCurrentTimeMillis();
+
+					JSONObject responseJSONObject = new JSONObject(
+						testrayServer.requestPost(
+							"/o/c/cases", requestJSONObject.toString()));
+
+					long end = JenkinsResultsParserUtil.getCurrentTimeMillis();
+
+					System.out.println(
+						JenkinsResultsParserUtil.combine(
+							"Testray Case '",
+							requestJSONObject.getString("name"),
+							"' created in ",
+							JenkinsResultsParserUtil.toDurationString(
+								end - start)));
+
+					return new TestrayCase(testrayProject, responseJSONObject);
 				}
 				catch (IOException ioException) {
 					throw new RuntimeException(ioException);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayFactory.java
@@ -7,6 +7,7 @@ package com.liferay.jenkins.results.parser.testray;
 
 import com.liferay.jenkins.results.parser.Build;
 import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+import com.liferay.jenkins.results.parser.Retryable;
 import com.liferay.jenkins.results.parser.TopLevelBuildReport;
 import com.liferay.jenkins.results.parser.test.clazz.BaseAntTargetTestClass;
 import com.liferay.jenkins.results.parser.test.clazz.TestClass;
@@ -18,12 +19,15 @@ import com.liferay.jenkins.results.parser.test.clazz.group.JUnitAxisTestClassGro
 import com.liferay.jenkins.results.parser.test.clazz.group.ModulesAxisTestClassGroup;
 import com.liferay.jenkins.results.parser.test.clazz.group.PlaywrightAxisTestClassGroup;
 
+import java.io.IOException;
+
 import java.net.MalformedURLException;
 import java.net.URL;
 
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -227,23 +231,129 @@ public class TestrayFactory {
 	public static TestrayBuild newTestrayBuild(
 		TestrayRoutine testrayRoutine, JSONObject jsonObject) {
 
-		return new TestrayBuild(testrayRoutine, jsonObject);
+		synchronized (_testrayBuilds) {
+			long id = jsonObject.getLong("id");
+
+			TestrayBuild testrayBuild = _testrayBuilds.get(id);
+
+			if (testrayBuild != null) {
+				return testrayBuild;
+			}
+
+			testrayBuild = new TestrayBuild(testrayRoutine, jsonObject);
+
+			_testrayBuilds.put(id, testrayBuild);
+
+			return testrayBuild;
+		}
 	}
 
 	public static TestrayBuild newTestrayBuild(
-		TestrayServer testrayServer, JSONObject jsonObject) {
+		TestrayRoutine testrayRoutine, long id) {
 
-		return new TestrayBuild(testrayServer, jsonObject);
+		synchronized (_testrayBuilds) {
+			TestrayBuild testrayBuild = _testrayBuilds.get(id);
+
+			if (testrayBuild != null) {
+				return testrayBuild;
+			}
+
+			testrayBuild = new TestrayBuild(testrayRoutine, id);
+
+			_testrayBuilds.put(id, testrayBuild);
+
+			return testrayBuild;
+		}
+	}
+
+	public static TestrayBuild newTestrayBuild(
+		TestrayServer testrayServer, long id) {
+
+		synchronized (_testrayBuilds) {
+			TestrayBuild testrayBuild = _testrayBuilds.get(id);
+
+			if (testrayBuild != null) {
+				return testrayBuild;
+			}
+
+			testrayBuild = new TestrayBuild(testrayServer, id);
+
+			_testrayBuilds.put(id, testrayBuild);
+
+			return testrayBuild;
+		}
 	}
 
 	public static TestrayBuild newTestrayBuild(URL url) {
-		return new TestrayBuild(url);
+		synchronized (_testrayBuilds) {
+			long id = TestrayBuild.getID(url);
+
+			if (id <= 0) {
+				return new TestrayBuild(url);
+			}
+
+			TestrayBuild testrayBuild = _testrayBuilds.get(id);
+
+			if (testrayBuild != null) {
+				return testrayBuild;
+			}
+
+			testrayBuild = new TestrayBuild(url);
+
+			_testrayBuilds.put(id, testrayBuild);
+
+			return testrayBuild;
+		}
 	}
 
 	public static TestrayCase newTestrayCase(
 		TestrayProject testrayProject, JSONObject jsonObject) {
 
 		return new TestrayCase(testrayProject, jsonObject);
+	}
+
+	public static TestrayCase newTestrayCase(
+		final TestrayProject testrayProject, String name,
+		TestrayCaseType testrayCaseType) {
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(name)) {
+			return null;
+		}
+
+		final String filterString = JenkinsResultsParserUtil.combine(
+			"name eq '", name, "' and ", "r_caseTypeToCases_c_caseTypeId eq '",
+			String.valueOf(testrayCaseType.getID()), "' and ",
+			"r_projectToCases_c_projectId eq '",
+			String.valueOf(testrayProject.getID()), "'");
+
+		final TestrayServer testrayServer = testrayProject.getTestrayServer();
+
+		Retryable<TestrayCase> retryable = new Retryable<TestrayCase>(
+			true, 3, 5, true) {
+
+			@Override
+			public TestrayCase execute() {
+				try {
+					Set<JSONObject> entityJSONObjects =
+						testrayServer.requestGraphQL(
+							"cases", TestrayCase.FIELD_NAMES, filterString,
+							null, 1, 1);
+
+					for (JSONObject entityJSONObject : entityJSONObjects) {
+						return new TestrayCase(
+							testrayProject, entityJSONObject);
+					}
+
+					return null;
+				}
+				catch (IOException ioException) {
+					throw new RuntimeException(ioException);
+				}
+			}
+
+		};
+
+		return retryable.executeWithRetries();
 	}
 
 	public static TestrayCaseType newTestrayCaseType(
@@ -592,6 +702,8 @@ public class TestrayFactory {
 		_testrayAttachmentRecorders = new ConcurrentHashMap<>();
 	private static final Map<String, TestrayAttachmentUploader>
 		_testrayAttachmentUploaders = new ConcurrentHashMap<>();
+	private static final Map<Long, TestrayBuild> _testrayBuilds =
+		new ConcurrentHashMap<>();
 	private static final Map<Long, TestrayFactor.Category>
 		_testrayFactorCategoriesIDs = new ConcurrentHashMap<>();
 	private static final Map<String, TestrayFactor.Category>

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayFactory.java
@@ -258,11 +258,33 @@ public class TestrayFactory {
 				return testrayBuild;
 			}
 
-			testrayBuild = new TestrayBuild(testrayRoutine, id);
+			String filterString = JenkinsResultsParserUtil.combine(
+				"id eq '", String.valueOf(id),
+				"' and r_routineToBuilds_c_routineId eq '",
+				String.valueOf(testrayRoutine.getID()), "'");
 
-			_testrayBuilds.put(id, testrayBuild);
+			TestrayServer testrayServer = testrayRoutine.getTestrayServer();
 
-			return testrayBuild;
+			try {
+				Set<JSONObject> entityJSONObjects =
+					testrayServer.requestGraphQL(
+						"builds", TestrayBuild.FIELD_NAMES, filterString, null,
+						1, 1);
+
+				for (JSONObject entityJSONObject : entityJSONObjects) {
+					testrayBuild = new TestrayBuild(
+						testrayRoutine, entityJSONObject);
+
+					_testrayBuilds.put(id, testrayBuild);
+
+					return testrayBuild;
+				}
+
+				return null;
+			}
+			catch (IOException ioException) {
+				throw new RuntimeException(ioException);
+			}
 		}
 	}
 
@@ -276,11 +298,26 @@ public class TestrayFactory {
 				return testrayBuild;
 			}
 
-			testrayBuild = new TestrayBuild(testrayServer, id);
+			try {
+				Set<JSONObject> entityJSONObjects =
+					testrayServer.requestGraphQL(
+						"builds", TestrayBuild.FIELD_NAMES,
+						"id eq '" + id + "'", null, 1, 1);
 
-			_testrayBuilds.put(id, testrayBuild);
+				for (JSONObject entityJSONObject : entityJSONObjects) {
+					testrayBuild = new TestrayBuild(
+						testrayServer, entityJSONObject);
 
-			return testrayBuild;
+					_testrayBuilds.put(id, testrayBuild);
+
+					return testrayBuild;
+				}
+
+				return null;
+			}
+			catch (IOException ioException) {
+				throw new RuntimeException(ioException);
+			}
 		}
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayImporter.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayImporter.java
@@ -993,13 +993,35 @@ public class TestrayImporter {
 				testBaseDir = axisTestClassGroup.getTestBaseDir();
 			}
 
-			_recordAppServerTestrayCaseResult(
-				job, PersistentResource.Type.ASAH_BUNDLE, testBaseDir);
-			_recordAppServerTestrayCaseResult(
-				job, PersistentResource.Type.FARO_BUNDLE, testBaseDir);
-			_recordAppServerTestrayCaseResult(
-				job, PersistentResource.Type.PORTAL_BUNDLE, testBaseDir);
-			_recordTopLevelTestrayCaseResult(job, testBaseDir);
+			final TestrayCaseResult topLevelTestrayCaseResult =
+				_recordTopLevelTestrayCaseResult(job, testBaseDir);
+
+			TestrayCaseResult asahAppServerTestrayCaseResult =
+				_recordAppServerTestrayCaseResult(
+					job, PersistentResource.Type.ASAH_BUNDLE, testBaseDir);
+
+			if (asahAppServerTestrayCaseResult != null) {
+				asahAppServerTestrayCaseResult.setParentTestrayCaseResult(
+					topLevelTestrayCaseResult);
+			}
+
+			TestrayCaseResult faroAppServerTestrayCaseResult =
+				_recordAppServerTestrayCaseResult(
+					job, PersistentResource.Type.FARO_BUNDLE, testBaseDir);
+
+			if (faroAppServerTestrayCaseResult != null) {
+				faroAppServerTestrayCaseResult.setParentTestrayCaseResult(
+					topLevelTestrayCaseResult);
+			}
+
+			TestrayCaseResult portalAppServerTestrayCaseResult =
+				_recordAppServerTestrayCaseResult(
+					job, PersistentResource.Type.PORTAL_BUNDLE, testBaseDir);
+
+			if (portalAppServerTestrayCaseResult != null) {
+				portalAppServerTestrayCaseResult.setParentTestrayCaseResult(
+					topLevelTestrayCaseResult);
+			}
 
 			for (final AxisTestClassGroup axisTestClassGroup :
 					axisTestClassGroups) {
@@ -1009,7 +1031,8 @@ public class TestrayImporter {
 
 						@Override
 						public Void call() throws Exception {
-							_recordAxisTestClassGroup(axisTestClassGroup);
+							_recordAxisTestClassGroup(
+								axisTestClassGroup, topLevelTestrayCaseResult);
 
 							return null;
 						}
@@ -1424,7 +1447,8 @@ public class TestrayImporter {
 	}
 
 	private void _recordAxisTestClassGroup(
-		AxisTestClassGroup axisTestClassGroup) {
+		AxisTestClassGroup axisTestClassGroup,
+		TestrayCaseResult topLevelTestrayCaseResult) {
 
 		Job job = axisTestClassGroup.getJob();
 
@@ -1487,6 +1511,9 @@ public class TestrayImporter {
 			TestrayFactory.newBuildTestrayCaseResult(
 				axisTestClassGroup, testrayBuild, _topLevelBuildReport);
 
+		buildTestrayCaseResult.setParentTestrayCaseResult(
+			topLevelTestrayCaseResult);
+
 		buildTestrayCaseResult.setTestrayRun(testrayRun);
 
 		testrayCaseResults.add(buildTestrayCaseResult);
@@ -1504,6 +1531,8 @@ public class TestrayImporter {
 			if (!JenkinsResultsParserUtil.isNullOrEmpty(
 					portalLogBatchBuildTestrayCaseResult.getErrors())) {
 
+				portalLogBatchBuildTestrayCaseResult.setParentTestrayCaseResult(
+					buildTestrayCaseResult);
 				portalLogBatchBuildTestrayCaseResult.setTestrayRun(testrayRun);
 
 				testrayCaseResults.add(portalLogBatchBuildTestrayCaseResult);
@@ -1515,6 +1544,8 @@ public class TestrayImporter {
 						axisTestClassGroup, testClass, testrayBuild,
 						_topLevelBuildReport);
 
+				testClassTestrayCaseResult.setParentTestrayCaseResult(
+					buildTestrayCaseResult);
 				testClassTestrayCaseResult.setTestrayRun(testrayRun);
 
 				testrayCaseResults.add(testClassTestrayCaseResult);
@@ -1530,6 +1561,8 @@ public class TestrayImporter {
 							axisTestClassGroup, testClass, testClassMethod,
 							testrayBuild, _topLevelBuildReport);
 
+					testClassMethodTestrayCaseResult.setParentTestrayCaseResult(
+						buildTestrayCaseResult);
 					testClassMethodTestrayCaseResult.setTestrayRun(testrayRun);
 
 					testrayCaseResults.add(testClassMethodTestrayCaseResult);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayImporter.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayImporter.java
@@ -266,8 +266,8 @@ public class TestrayImporter {
 				getTestrayProductVersion(testBaseDir);
 
 			if ((testrayBuildID != null) && testrayBuildID.matches("\\d+")) {
-				testrayBuild = testrayRoutine.getTestrayBuildByID(
-					Long.parseLong(testrayBuildID));
+				testrayBuild = TestrayFactory.newTestrayBuild(
+					testrayRoutine, Long.parseLong(testrayBuildID));
 			}
 
 			String testrayBuildName = Environment.get("TESTRAY_BUILD_NAME");
@@ -286,8 +286,8 @@ public class TestrayImporter {
 			if ((testrayBuild == null) && (testrayBuildID != null) &&
 				testrayBuildID.matches("\\d+")) {
 
-				testrayBuild = testrayRoutine.getTestrayBuildByID(
-					Long.parseLong(testrayBuildID));
+				testrayBuild = TestrayFactory.newTestrayBuild(
+					testrayRoutine, Long.parseLong(testrayBuildID));
 			}
 
 			testrayBuildName = _getBuildParameter("TESTRAY_BUILD_NAME");
@@ -310,8 +310,8 @@ public class TestrayImporter {
 				if ((testrayBuildID != null) &&
 					testrayBuildID.matches("\\d+")) {
 
-					testrayBuild = testrayRoutine.getTestrayBuildByID(
-						Long.parseLong(testrayBuildID));
+					testrayBuild = TestrayFactory.newTestrayBuild(
+						testrayRoutine, Long.parseLong(testrayBuildID));
 				}
 			}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayProject.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayProject.java
@@ -109,29 +109,8 @@ public class TestrayProject {
 	public TestrayCase getTestrayCase(
 		String testCaseName, TestrayCaseType testrayCaseType) {
 
-		String filterString = JenkinsResultsParserUtil.combine(
-			"name eq '", testCaseName, "' and ",
-			"r_caseTypeToCases_c_caseTypeId eq '",
-			String.valueOf(testrayCaseType.getID()), "' and ",
-			"r_projectToCases_c_projectId eq '", String.valueOf(getID()), "'");
-
-		try {
-			Set<JSONObject> entityJSONObjects = _testrayServer.requestGraphQL(
-				"cases", TestrayCase.FIELD_NAMES, filterString, null, 1, 1);
-
-			if (entityJSONObjects.isEmpty()) {
-				return null;
-			}
-
-			for (JSONObject entityJSONObject : entityJSONObjects) {
-				return TestrayFactory.newTestrayCase(this, entityJSONObject);
-			}
-
-			return null;
-		}
-		catch (IOException ioException) {
-			throw new RuntimeException(ioException);
-		}
+		return TestrayFactory.newTestrayCase(
+			this, testCaseName, testrayCaseType);
 	}
 
 	public TestrayCase getTestrayCaseByName(String testCaseName) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayRoutine.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayRoutine.java
@@ -91,7 +91,8 @@ public class TestrayRoutine {
 				_testrayServer.requestPost(
 					"/o/c/builds", requestJSONObject.toString()));
 
-			return getTestrayBuildByID(responseJSONObject.getLong("id"));
+			return TestrayFactory.newTestrayBuild(
+				this, responseJSONObject.getLong("id"));
 		}
 		catch (IOException ioException) {
 			throw new RuntimeException(
@@ -112,36 +113,10 @@ public class TestrayRoutine {
 	}
 
 	public TestrayBuild getTestrayBuildByID(long buildID) {
-		TestrayBuild testrayBuild = _testrayServer.getTestrayBuildByID(buildID);
-
-		if (testrayBuild != null) {
-			return testrayBuild;
-		}
-
-		String filterString = JenkinsResultsParserUtil.combine(
-			"id eq '", String.valueOf(buildID), "' and ",
-			"r_routineToBuilds_c_routineId eq '", String.valueOf(getID()), "'");
-
-		try {
-			Set<JSONObject> entityJSONObjects = _testrayServer.requestGraphQL(
-				"builds", TestrayBuild.FIELD_NAMES, filterString, null, 1, 1);
-
-			if (entityJSONObjects.isEmpty()) {
-				return null;
-			}
-
-			Iterator<JSONObject> iterator = entityJSONObjects.iterator();
-
-			return TestrayFactory.newTestrayBuild(this, iterator.next());
-		}
-		catch (IOException ioException) {
-			throw new RuntimeException(ioException);
-		}
+		return TestrayFactory.newTestrayBuild(_testrayServer, buildID);
 	}
 
-	public TestrayBuild getTestrayBuildByName(
-		String buildName, String... names) {
-
+	public TestrayBuild getTestrayBuildByName(String buildName) {
 		if (JenkinsResultsParserUtil.isNullOrEmpty(buildName)) {
 			return null;
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TopLevelStandaloneBuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TopLevelStandaloneBuildTestrayCaseResult.java
@@ -9,6 +9,10 @@ import com.liferay.jenkins.results.parser.JenkinsMaster;
 import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
 import com.liferay.jenkins.results.parser.TopLevelBuildReport;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 /**
  * @author Michael Hashimoto
  */
@@ -26,6 +30,21 @@ public class TopLevelStandaloneBuildTestrayCaseResult
 	@Override
 	public String getName() {
 		return "Top Level Build";
+	}
+
+	@Override
+	public List<TestrayAttachment> getTestrayAttachments() {
+		List<TestrayAttachment> testrayAttachments = new ArrayList<>();
+
+		testrayAttachments.add(getTopLevelBuildDatabaseTestrayAttachment());
+		testrayAttachments.add(getTopLevelBuildReportTestrayAttachment());
+		testrayAttachments.add(getTopLevelJenkinsConsoleTestrayAttachment());
+		testrayAttachments.add(getTopLevelJenkinsReportTestrayAttachment());
+		testrayAttachments.add(getTopLevelJobSummaryTestrayAttachment());
+
+		testrayAttachments.removeAll(Collections.singleton(null));
+
+		return testrayAttachments;
 	}
 
 	@Override


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-6956

## What Is Being Fixed

The Testray XML import only repairs entries that do not yet exist, so case results had to be pre-populated through the REST API before the import ran. The existing code could not do this safely: a missing Testray build ID threw a RuntimeException instead of letting TestrayImporter fall back to the TESTRAY_BUILD_NAME environment variable, build parameters, and job properties, and a null build still posted an orphan case result before failing with a NullPointerException inside the retryable.

## How It Is Being Fixed

Object lookup and caching move out of the individual Testray classes into TestrayFactory, which now constructs cached TestrayBuild, TestrayCase, TestrayProject, and TestrayRoutine instances and returns null when a build ID does not match any build, restoring the importer's fallback chain. On that foundation, the importer creates Testray cases and case results through the REST API when they do not already exist and sets each downstream case result's parent to the corresponding top-level case result. An attachment-handling layer is added (attachment JSON serialization, the parent-case-result-as-attachment helper, and per-result-type getTestrayAttachments overrides), and case result creation now bails out early when the build or case is null instead of posting an orphan record.

## Why Are There No Tests?

jenkins-results-parser is CI infrastructure code without a unit test harness for these classes; the change is validated by running real Jenkins builds against Testray.

## PR Check

**pr-check: PASS** — tested on `d5920cee21b62302b2f7e3ec3a48ca121b602ab6`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "d5920cee21b62302b2f7e3ec3a48ca121b602ab6"} -->