### PR TITLE
LRCI-7515 Add intra-axis parallelism for Testray case-result recording

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuildReport.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuildReport.java
@@ -135,7 +135,7 @@ public abstract class BaseBuildReport implements BuildReport {
 	}
 
 	@Override
-	public JenkinsMaster getJenkinsMaster() {
+	public synchronized JenkinsMaster getJenkinsMaster() {
 		if (_jenkinsMaster != null) {
 			return _jenkinsMaster;
 		}
@@ -199,7 +199,7 @@ public abstract class BaseBuildReport implements BuildReport {
 	}
 
 	@Override
-	public URL getTestrayAttachmentURLBySuffix(String suffix) {
+	public synchronized URL getTestrayAttachmentURLBySuffix(String suffix) {
 		if (_testrayAttachmentURLsBySuffix.containsKey(suffix)) {
 			return _testrayAttachmentURLsBySuffix.get(suffix);
 		}
@@ -223,7 +223,7 @@ public abstract class BaseBuildReport implements BuildReport {
 	}
 
 	@Override
-	public List<URL> getTestrayAttachmentURLs() {
+	public synchronized List<URL> getTestrayAttachmentURLs() {
 		if (_testrayAttachmentURLs != null) {
 			return _testrayAttachmentURLs;
 		}
@@ -301,7 +301,7 @@ public abstract class BaseBuildReport implements BuildReport {
 		}
 	}
 
-	protected void clearTestrayAttachmentURLCaches() {
+	protected synchronized void clearTestrayAttachmentURLCaches() {
 		_testrayAttachmentURLs = null;
 
 		_testrayAttachmentURLsBySuffix.clear();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseDownstreamBuildReport.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseDownstreamBuildReport.java
@@ -94,7 +94,7 @@ public abstract class BaseDownstreamBuildReport
 	}
 
 	@Override
-	public List<TestClassReport> getTestClassReports() {
+	public synchronized List<TestClassReport> getTestClassReports() {
 		if (_testClassReportsMap != null) {
 			return new ArrayList<>(_testClassReportsMap.values());
 		}
@@ -121,7 +121,7 @@ public abstract class BaseDownstreamBuildReport
 	}
 
 	@Override
-	public List<TestReport> getTestReports() {
+	public synchronized List<TestReport> getTestReports() {
 		if (_testReports != null) {
 			return _testReports;
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseTopLevelBuildReport.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseTopLevelBuildReport.java
@@ -32,7 +32,7 @@ public abstract class BaseTopLevelBuildReport
 	extends BaseBuildReport implements TopLevelBuildReport {
 
 	@Override
-	public void addDownstreamBuildReport(
+	public synchronized void addDownstreamBuildReport(
 		DownstreamBuildReport downstreamBuildReport) {
 
 		if (downstreamBuildReport == null) {
@@ -154,7 +154,7 @@ public abstract class BaseTopLevelBuildReport
 	}
 
 	@Override
-	public ControllerBuildReport getControllerBuildReport() {
+	public synchronized ControllerBuildReport getControllerBuildReport() {
 		if (_controllerBuildReport != null) {
 			return _controllerBuildReport;
 		}
@@ -181,7 +181,7 @@ public abstract class BaseTopLevelBuildReport
 	}
 
 	@Override
-	public List<FailureReport> getDistinctFailureReports() {
+	public synchronized List<FailureReport> getDistinctFailureReports() {
 		if (_distinctFailureReports != null) {
 			return _distinctFailureReports;
 		}
@@ -210,7 +210,9 @@ public abstract class BaseTopLevelBuildReport
 	}
 
 	@Override
-	public DownstreamBuildReport getDownstreamBuildReport(String axisName) {
+	public synchronized DownstreamBuildReport getDownstreamBuildReport(
+		String axisName) {
+
 		for (DownstreamBuildReport downstreamBuildReport :
 				_downstreamBuildReports) {
 
@@ -233,7 +235,9 @@ public abstract class BaseTopLevelBuildReport
 	}
 
 	@Override
-	public List<DownstreamBuildReport> getDownstreamBuildReports() {
+	public synchronized List<DownstreamBuildReport>
+		getDownstreamBuildReports() {
+
 		List<DownstreamBuildReport> downstreamBuildReports = new ArrayList<>();
 
 		downstreamBuildReports.addAll(_cachedDownstreamBuildReports);
@@ -243,7 +247,7 @@ public abstract class BaseTopLevelBuildReport
 	}
 
 	@Override
-	public List<FailureReport> getFailureReports() {
+	public synchronized List<FailureReport> getFailureReports() {
 		if (_failureReports != null) {
 			return _failureReports;
 		}
@@ -280,7 +284,7 @@ public abstract class BaseTopLevelBuildReport
 	}
 
 	@Override
-	public JobReport getJobReport() {
+	public synchronized JobReport getJobReport() {
 		if (_jobReport != null) {
 			return _jobReport;
 		}
@@ -304,7 +308,7 @@ public abstract class BaseTopLevelBuildReport
 	}
 
 	@Override
-	public TopLevelBuildReport getPreviousTopLevelBuildReport() {
+	public synchronized TopLevelBuildReport getPreviousTopLevelBuildReport() {
 		if (_previousTopLevelBuildReport != null) {
 			return _previousTopLevelBuildReport;
 		}
@@ -528,7 +532,7 @@ public abstract class BaseTopLevelBuildReport
 	}
 
 	@Override
-	public List<FailureReport> getUniqueFailureReports() {
+	public synchronized List<FailureReport> getUniqueFailureReports() {
 		if (_uniqueFailureReports != null) {
 			return _uniqueFailureReports;
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BatchBuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BatchBuildTestrayCaseResult.java
@@ -359,6 +359,10 @@ public class BatchBuildTestrayCaseResult
 		return null;
 	}
 
+	protected TestReport findTestReport() {
+		return null;
+	}
+
 	protected AxisTestClassGroup getAxisTestClassGroup() {
 		return _axisTestClassGroup;
 	}
@@ -430,7 +434,12 @@ public class BatchBuildTestrayCaseResult
 	}
 
 	protected TestReport getTestReport() {
-		return null;
+		if (!_testReportComputed) {
+			_testReport = findTestReport();
+			_testReportComputed = true;
+		}
+
+		return _testReport;
 	}
 
 	protected long getTestResultDuration() {
@@ -830,6 +839,8 @@ public class BatchBuildTestrayCaseResult
 	private final AxisTestClassGroup _axisTestClassGroup;
 	private A _testClass;
 	private B _testClassMethod;
+	private TestReport _testReport;
+	private boolean _testReportComputed;
 	private TopLevelStandaloneBuildTestrayCaseResult
 		_topLevelStandaloneBuildTestrayCaseResult;
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BuildTestrayCaseResult.java
@@ -107,7 +107,7 @@ public abstract class BuildTestrayCaseResult extends TestrayCaseResult {
 			parentTestrayCaseResultURL);
 	}
 
-	protected TestrayAttachment getTestrayAttachment(
+	protected synchronized TestrayAttachment getTestrayAttachment(
 		BuildReport buildReport, String name, String key) {
 
 		if (_testrayAttachments.containsKey(key)) {
@@ -262,7 +262,7 @@ public abstract class BuildTestrayCaseResult extends TestrayCaseResult {
 		_buildReport = buildReport;
 	}
 
-	protected TestrayAttachment uploadTestrayAttachment(
+	protected synchronized TestrayAttachment uploadTestrayAttachment(
 		String name, String key, Callable<File> callable) {
 
 		File file = null;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/FunctionalBatchBuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/FunctionalBatchBuildTestrayCaseResult.java
@@ -121,7 +121,7 @@ public class FunctionalBatchBuildTestrayCaseResult
 	}
 
 	@Override
-	public TestReport getTestReport() {
+	protected TestReport findTestReport() {
 		FunctionalTestClass functionalTestClass = getTestClass();
 
 		if (functionalTestClass.isBuildCachingEnabled()) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/PlaywrightBatchBuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/PlaywrightBatchBuildTestrayCaseResult.java
@@ -191,7 +191,7 @@ public class PlaywrightBatchBuildTestrayCaseResult
 	}
 
 	@Override
-	public TestReport getTestReport() {
+	protected TestReport findTestReport() {
 		PlaywrightTestClassMethod playwrightTestClassMethod =
 			getTestClassMethod();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCaseResult.java
@@ -523,6 +523,10 @@ public class TestrayCaseResult {
 		}
 	}
 
+	protected void cacheTestrayCaseResultURL() {
+		getTestrayCaseResultURL();
+	}
+
 	protected synchronized void initTestrayAttachments() {
 		if (testrayAttachments != null) {
 			return;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCaseResult.java
@@ -176,7 +176,7 @@ public class TestrayCaseResult {
 		return "";
 	}
 
-	public String getTeamName() {
+	public synchronized String getTeamName() {
 		if (_testrayComponent == null) {
 			return null;
 		}
@@ -192,7 +192,7 @@ public class TestrayCaseResult {
 		return new ArrayList<>(testrayAttachments.values());
 	}
 
-	public TestrayBuild getTestrayBuild() {
+	public synchronized TestrayBuild getTestrayBuild() {
 		if (_testrayBuild != null) {
 			return _testrayBuild;
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCloudBucket.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCloudBucket.java
@@ -58,7 +58,7 @@ public class TestrayCloudBucket {
 		return getInstance(name);
 	}
 
-	public static TestrayCloudBucket getInstance(String name) {
+	public static synchronized TestrayCloudBucket getInstance(String name) {
 		if (JenkinsResultsParserUtil.isNullOrEmpty(name)) {
 			name = DEFAULT_BUCKET_NAME;
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayFactory.java
@@ -757,7 +757,7 @@ public class TestrayFactory {
 		return new TestrayTeam(testrayProject, jsonObject);
 	}
 
-	public static TopLevelStandaloneBuildTestrayCaseResult
+	public static synchronized TopLevelStandaloneBuildTestrayCaseResult
 		newTopLevelStandaloneBuildTestrayCaseResult(
 			TestrayBuild testrayBuild,
 			TopLevelBuildReport topLevelBuildReport) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayImporter.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayImporter.java
@@ -1402,6 +1402,156 @@ public class TestrayImporter {
 		return "Liferay CI";
 	}
 
+	private Element _getTestcaseElement(
+		TestrayCaseResult testrayCaseResult, String testSuiteName,
+		String[] warnings) {
+
+		Element testcaseElement = Dom4JUtil.getNewElement("testcase");
+
+		Map<String, String> testcasePropertiesMap = new HashMap<>();
+
+		testcasePropertiesMap.put(
+			"testray.case.type.name", testrayCaseResult.getType());
+		testcasePropertiesMap.put(
+			"testray.component.names",
+			testrayCaseResult.getSubcomponentNames());
+		testcasePropertiesMap.put(
+			"testray.main.component.name",
+			testrayCaseResult.getComponentName());
+		testcasePropertiesMap.put(
+			"testray.team.name", testrayCaseResult.getTeamName());
+		testcasePropertiesMap.put(
+			"testray.testcase.duration",
+			String.valueOf(testrayCaseResult.getDuration()));
+
+		String testrayCaseName = testrayCaseResult.getName();
+
+		if (testrayCaseName.length() > 150) {
+			testrayCaseName = testrayCaseName.substring(0, 150);
+		}
+
+		testcasePropertiesMap.put("testray.testcase.name", testrayCaseName);
+
+		testcasePropertiesMap.put(
+			"testray.testcase.priority",
+			String.valueOf(testrayCaseResult.getPriority()));
+
+		TestrayCaseResult.Status testrayCaseStatus =
+			testrayCaseResult.getStatus();
+
+		testcasePropertiesMap.put(
+			"testray.testcase.status", testrayCaseStatus.getName());
+
+		Element propertiesElement = testcaseElement.addElement("properties");
+
+		if (testSuiteName.equals("upstream-dxp")) {
+			if (testrayCaseResult instanceof JUnitBatchBuildTestrayCaseResult) {
+				_addDetailsElements(
+					propertiesElement,
+					(JUnitBatchBuildTestrayCaseResult)testrayCaseResult);
+			}
+			else {
+				testcasePropertiesMap.put(
+					"testray.jira.issues", testrayCaseResult.getIssues());
+			}
+		}
+
+		_addPropertyElements(propertiesElement, testcasePropertiesMap);
+
+		if ((warnings != null) && (warnings.length > 0)) {
+			Element warningsPropertyElement = propertiesElement.addElement(
+				"property");
+
+			warningsPropertyElement.addAttribute(
+				"name", "testray.testcase.warnings");
+			warningsPropertyElement.addAttribute(
+				"value", String.valueOf(warnings.length));
+
+			for (String warning : warnings) {
+				Element warningPropertyElement =
+					warningsPropertyElement.addElement("value");
+
+				warningPropertyElement.addText(
+					StringEscapeUtils.escapeHtml4(warning));
+			}
+		}
+
+		Element attachmentsElement = testcaseElement.addElement("attachments");
+
+		for (TestrayAttachment testrayAttachment :
+				testrayCaseResult.getTestrayAttachments()) {
+
+			Element attachmentFileElement = attachmentsElement.addElement(
+				"file");
+
+			attachmentFileElement.addAttribute(
+				"name", testrayAttachment.getName());
+			attachmentFileElement.addAttribute(
+				"url", testrayAttachment.getURL() + "?authuser=0");
+			attachmentFileElement.addAttribute(
+				"value", testrayAttachment.getKey() + "?authuser=0");
+		}
+
+		String errors = testrayCaseResult.getErrors();
+
+		if (!JenkinsResultsParserUtil.isNullOrEmpty(errors)) {
+			Element failureElement = testcaseElement.addElement("failure");
+
+			failureElement.addAttribute("message", errors);
+		}
+
+		return testcaseElement;
+	}
+
+	private List<Element> _getTestcaseElements(
+		AxisTestClassGroup axisTestClassGroup,
+		List<TestrayCaseResult> testrayCaseResults, String testSuiteName) {
+
+		final String[] testrayCaseResultWarnings =
+			_getTestrayCaseResultWarnings(testrayCaseResults);
+
+		List<Callable<Element>> callables = new ArrayList<>();
+
+		for (final TestrayCaseResult testrayCaseResult : testrayCaseResults) {
+			callables.add(
+				new Callable<Element>() {
+
+					@Override
+					public Element call() throws Exception {
+						return _getTestcaseElement(
+							testrayCaseResult, testSuiteName,
+							testrayCaseResultWarnings);
+					}
+
+				});
+		}
+
+		ParallelExecutor<Element> parallelExecutor = new ParallelExecutor<>(
+			callables, true, _caseResultExecutorService, true,
+			"recordAxisTestClassGroup:" + axisTestClassGroup.getAxisName());
+
+		try {
+			return parallelExecutor.execute(60L * 30L);
+		}
+		catch (TimeoutException timeoutException) {
+			throw new RuntimeException(timeoutException);
+		}
+	}
+
+	private String[] _getTestrayCaseResultWarnings(
+		List<TestrayCaseResult> testrayCaseResults) {
+
+		for (TestrayCaseResult testrayCaseResult : testrayCaseResults) {
+			String[] warnings = testrayCaseResult.getWarnings();
+
+			if (warnings != null) {
+				return warnings;
+			}
+		}
+
+		return null;
+	}
+
 	private TestrayCaseResult _recordAppServerTestrayCaseResult(
 		Job job, PersistentResource.Type persistentResourceType,
 		File testBaseDir, TestrayCaseResult topLevelTestrayCaseResult) {
@@ -1487,8 +1637,6 @@ public class TestrayImporter {
 		_addPropertyElements(
 			rootElement.addElement("properties"), propertiesMap);
 
-		String[] warnings = null;
-
 		List<TestrayCaseResult> testrayCaseResults = new ArrayList<>();
 
 		TestrayCaseResult buildTestrayCaseResult =
@@ -1554,110 +1702,12 @@ public class TestrayImporter {
 			}
 		}
 
-		for (TestrayCaseResult testrayCaseResult : testrayCaseResults) {
-			Element testcaseElement = rootElement.addElement("testcase");
+		List<Element> testcaseElements = _getTestcaseElements(
+			axisTestClassGroup, testrayCaseResults,
+			_topLevelBuildReport.getTestSuiteName());
 
-			Map<String, String> testcasePropertiesMap = new HashMap<>();
-
-			testcasePropertiesMap.put(
-				"testray.case.type.name", testrayCaseResult.getType());
-			testcasePropertiesMap.put(
-				"testray.component.names",
-				testrayCaseResult.getSubcomponentNames());
-			testcasePropertiesMap.put(
-				"testray.main.component.name",
-				testrayCaseResult.getComponentName());
-			testcasePropertiesMap.put(
-				"testray.team.name", testrayCaseResult.getTeamName());
-			testcasePropertiesMap.put(
-				"testray.testcase.duration",
-				String.valueOf(testrayCaseResult.getDuration()));
-
-			String testrayCaseName = testrayCaseResult.getName();
-
-			if (testrayCaseName.length() > 150) {
-				testrayCaseName = testrayCaseName.substring(0, 150);
-			}
-
-			testcasePropertiesMap.put("testray.testcase.name", testrayCaseName);
-
-			testcasePropertiesMap.put(
-				"testray.testcase.priority",
-				String.valueOf(testrayCaseResult.getPriority()));
-
-			TestrayCaseResult.Status testrayCaseStatus =
-				testrayCaseResult.getStatus();
-
-			testcasePropertiesMap.put(
-				"testray.testcase.status", testrayCaseStatus.getName());
-
-			Element propertiesElement = testcaseElement.addElement(
-				"properties");
-
-			String testSuiteName = _topLevelBuildReport.getTestSuiteName();
-
-			if (testSuiteName.equals("upstream-dxp")) {
-				if (testrayCaseResult instanceof
-						JUnitBatchBuildTestrayCaseResult) {
-
-					_addDetailsElements(
-						propertiesElement,
-						(JUnitBatchBuildTestrayCaseResult)testrayCaseResult);
-				}
-				else {
-					testcasePropertiesMap.put(
-						"testray.jira.issues", testrayCaseResult.getIssues());
-				}
-			}
-
-			_addPropertyElements(propertiesElement, testcasePropertiesMap);
-
-			if (warnings == null) {
-				warnings = testrayCaseResult.getWarnings();
-			}
-
-			if ((warnings != null) && (warnings.length > 0)) {
-				Element warningsPropertyElement = propertiesElement.addElement(
-					"property");
-
-				warningsPropertyElement.addAttribute(
-					"name", "testray.testcase.warnings");
-				warningsPropertyElement.addAttribute(
-					"value", String.valueOf(warnings.length));
-
-				for (String warning : warnings) {
-					Element warningPropertyElement =
-						warningsPropertyElement.addElement("value");
-
-					warningPropertyElement.addText(
-						StringEscapeUtils.escapeHtml4(warning));
-				}
-			}
-
-			Element attachmentsElement = testcaseElement.addElement(
-				"attachments");
-
-			for (TestrayAttachment testrayAttachment :
-					testrayCaseResult.getTestrayAttachments()) {
-
-				Element attachmentFileElement = attachmentsElement.addElement(
-					"file");
-
-				attachmentFileElement.addAttribute(
-					"name", testrayAttachment.getName());
-				attachmentFileElement.addAttribute(
-					"url", testrayAttachment.getURL() + "?authuser=0");
-				attachmentFileElement.addAttribute(
-					"value", testrayAttachment.getKey() + "?authuser=0");
-			}
-
-			String errors = testrayCaseResult.getErrors();
-
-			if (!JenkinsResultsParserUtil.isNullOrEmpty(errors)) {
-				Element failureElement = testcaseElement.addElement("failure");
-
-				failureElement.addAttribute("message", errors);
-			}
+		for (Element testcaseElement : testcaseElements) {
+			rootElement.add(testcaseElement);
 		}
 
 		TestrayServer testrayServer = testrayBuild.getTestrayServer();
@@ -2161,6 +2211,8 @@ public class TestrayImporter {
 		pullRequest.addComment(getJenkinsBuildDescription());
 	}
 
+	private static final ExecutorService _caseResultExecutorService =
+		JenkinsResultsParserUtil.getNewThreadPoolExecutor(20, true);
 	private static final ExecutorService _executorService =
 		JenkinsResultsParserUtil.getNewThreadPoolExecutor(10, true);
 	private static final Pattern _quarterlyReleaseVersionPattern =

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayImporter.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayImporter.java
@@ -1507,8 +1507,6 @@ public class TestrayImporter {
 		AxisTestClassGroup axisTestClassGroup,
 		List<TestrayCaseResult> testrayCaseResults, String testSuiteName) {
 
-		_preloadParentTestrayCaseResults(testrayCaseResults);
-
 		final String[] testrayCaseResultWarnings =
 			_getTestrayCaseResultWarnings(testrayCaseResults);
 
@@ -1552,23 +1550,6 @@ public class TestrayImporter {
 		}
 
 		return null;
-	}
-
-	private void _preloadParentTestrayCaseResults(
-		List<TestrayCaseResult> testrayCaseResults) {
-
-		for (TestrayCaseResult testrayCaseResult : testrayCaseResults) {
-			TestrayCaseResult parentTestrayCaseResult =
-				testrayCaseResult.getParentTestrayCaseResult();
-
-			if (parentTestrayCaseResult == null) {
-				continue;
-			}
-
-			parentTestrayCaseResult.getName();
-			parentTestrayCaseResult.getTestrayCaseResultURL();
-			parentTestrayCaseResult.getTestrayComponent();
-		}
 	}
 
 	private TestrayCaseResult _recordAppServerTestrayCaseResult(
@@ -1666,6 +1647,8 @@ public class TestrayImporter {
 			topLevelTestrayCaseResult);
 
 		buildTestrayCaseResult.setTestrayRun(testrayRun);
+
+		buildTestrayCaseResult.cacheTestrayCaseResultURL();
 
 		testrayCaseResults.add(buildTestrayCaseResult);
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayImporter.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayImporter.java
@@ -1507,6 +1507,8 @@ public class TestrayImporter {
 		AxisTestClassGroup axisTestClassGroup,
 		List<TestrayCaseResult> testrayCaseResults, String testSuiteName) {
 
+		_preloadParentTestrayCaseResults(testrayCaseResults);
+
 		final String[] testrayCaseResultWarnings =
 			_getTestrayCaseResultWarnings(testrayCaseResults);
 
@@ -1550,6 +1552,23 @@ public class TestrayImporter {
 		}
 
 		return null;
+	}
+
+	private void _preloadParentTestrayCaseResults(
+		List<TestrayCaseResult> testrayCaseResults) {
+
+		for (TestrayCaseResult testrayCaseResult : testrayCaseResults) {
+			TestrayCaseResult parentTestrayCaseResult =
+				testrayCaseResult.getParentTestrayCaseResult();
+
+			if (parentTestrayCaseResult == null) {
+				continue;
+			}
+
+			parentTestrayCaseResult.getName();
+			parentTestrayCaseResult.getTestrayCaseResultURL();
+			parentTestrayCaseResult.getTestrayComponent();
+		}
 	}
 
 	private TestrayCaseResult _recordAppServerTestrayCaseResult(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7515
https://liferay.atlassian.net/browse/LRCI-7513

## What Is Being Fixed

After the LRCI-6672 caching work, `recordTestrayCaseResults` is throughput-bound: each axis builds its case-result XML sequentially, so the heaviest Playwright axes dominate the total wallclock. Separately, `getTestReport()` is re-resolved several times per case-result (for duration, status, errors, and the Playwright trace-viewer lookup), repeating the same per-instance lookup work each time.

## How It Is Being Fixed

LRCI-7515 dispatches per-case-result XML construction across a shared worker pool within each axis. Each worker builds a detached dom4j subtree, and the results are attached to the root element sequentially after the pool completes, so dom4j is never mutated concurrently. Shared per-build-report caches accessed by the workers are made thread-safe with synchronized accessors (the caches negative-cache null, so a ConcurrentHashMap is not an option). The shared parent case-result's lazily-resolved URL is warmed once, sequentially, before the fan-out via `TestrayCaseResult.cacheTestrayCaseResultURL()`, so the workers hit a warm, already-synchronized getter instead of serializing on the parent monitor during its expensive network resolution.

LRCI-7513 memoizes `getTestReport()` on each case-result instance behind a computed-once sentinel, collapsing the repeated per-case resolutions to a single lookup. Each case-result instance is processed by exactly one worker, so the memo needs no synchronization.

## Why Are There No Tests?

The jenkins-results-parser Testray-recording path has no unit-test harness — there are no case-result or `TestrayImporter` unit tests to extend. The change is validated by re-running the `publish-testray-report` job against a baseline build's data and diffing the Testray output (case counts, statuses, attachments) and wallclock against the master jar; correctness and the throughput win were confirmed across acceptance and publish-testray runs.

## PR Check

**pr-check: PASS** — tested on `4d98a043f65d626083c117e19aa6fa95204ca6dc`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

Java Unit Tests: 81 of 82 module unit tests passed. The 1 failure (`PropertyValidatorTest.testValidate`) is a pre-existing issue on `master` — it reports undefined build properties consumed by `HeapDumpCloudUploader` and `BuildQueueRebalancer`, neither of which this change touches.

<!-- pr-check {"result": "success", "sha": "4d98a043f65d626083c117e19aa6fa95204ca6dc"} -->
