### PR TITLE
LRCI-7759 Support generating build properties for local usage

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/EnvironmentBuildProperties.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/EnvironmentBuildProperties.java
@@ -26,16 +26,22 @@ import java.util.regex.Pattern;
 public class EnvironmentBuildProperties extends Properties {
 
 	public static Environment getCurrentEnvironment() {
+		String jenkinsURL = System.getenv("JENKINS_URL");
+
+		if (!JenkinsResultsParserUtil.isURL(jenkinsURL)) {
+			return Environment.LOCAL;
+		}
+
 		String masterNetworkName = System.getenv("MASTER_NETWORK_NAME");
 
 		if (!JenkinsResultsParserUtil.isNullOrEmpty(masterNetworkName) &&
-			(masterNetworkName.equals("aws-network") ||
-			 masterNetworkName.equals("gcp-network"))) {
+			(masterNetworkName.equals("cloud-network") ||
+			 masterNetworkName.equals("nuc-network"))) {
 
-			return Environment.AWS;
+			return Environment.DB;
 		}
 
-		return Environment.DB;
+		return Environment.AWS;
 	}
 
 	public static String toURLString(File file) throws IOException {
@@ -154,7 +160,7 @@ public class EnvironmentBuildProperties extends Properties {
 
 	public enum Environment {
 
-		AWS("aws-master", "aws"), DB("master", "db");
+		AWS("aws-master", "aws"), DB("master", "db"), LOCAL("master", "local");
 
 		public String getBranchName() {
 			return _branchName;
@@ -185,10 +191,16 @@ public class EnvironmentBuildProperties extends Properties {
 		return sb.toString();
 	}
 
-	private void _loadLocalProperties(String urlString, boolean checkCache) {
-		if (!JenkinsResultsParserUtil.isNullOrEmpty(
-				System.getenv("JENKINS_URL"))) {
+	private boolean _isLocal() {
+		if (getCurrentEnvironment() == Environment.LOCAL) {
+			return true;
+		}
 
+		return false;
+	}
+
+	private void _loadLocalProperties(String urlString, boolean checkCache) {
+		if (!_isLocal()) {
 			return;
 		}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/EnvironmentBuildProperties.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/EnvironmentBuildProperties.java
@@ -65,6 +65,8 @@ public class EnvironmentBuildProperties extends Properties {
 
 			load(new StringReader(contents));
 
+			_loadLocalProperties(urlString, checkCache);
+
 			return;
 		}
 		catch (IOException ioException) {
@@ -99,6 +101,8 @@ public class EnvironmentBuildProperties extends Properties {
 		}
 		catch (IOException ioException) {
 		}
+
+		_loadLocalProperties(urlString, checkCache);
 	}
 
 	public EnvironmentBuildProperties(File file) throws IOException {
@@ -179,6 +183,31 @@ public class EnvironmentBuildProperties extends Properties {
 		sb.append(_simpleDateFormat.format(new Date()));
 
 		return sb.toString();
+	}
+
+	private void _loadLocalProperties(String urlString, boolean checkCache) {
+		if (!JenkinsResultsParserUtil.isNullOrEmpty(
+				System.getenv("JENKINS_URL"))) {
+
+			return;
+		}
+
+		Matcher matcher = _propertiesURLPattern.matcher(urlString);
+
+		if (!matcher.matches()) {
+			return;
+		}
+
+		try {
+			String content = _toString(
+				JenkinsResultsParserUtil.combine(
+					matcher.group(1), "-local", matcher.group(2)),
+				checkCache);
+
+			load(new StringReader(content));
+		}
+		catch (IOException ioException) {
+		}
 	}
 
 	private String _toString(String url, boolean checkCache)

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/EnvironmentBuildPropertiesUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/EnvironmentBuildPropertiesUtil.java
@@ -63,6 +63,18 @@ public class EnvironmentBuildPropertiesUtil {
 						"github.webhook.url[aws-staging]"));
 			}
 
+			if (environment != EnvironmentBuildProperties.Environment.LOCAL) {
+				for (String propertyName :
+						environmentBuildProperties.stringPropertyNames()) {
+
+					environmentBuildProperties.setProperty(
+						propertyName,
+						SecretsUtil.getSecret(
+							environmentBuildProperties.getProperty(
+								propertyName)));
+				}
+			}
+
 			environmentBuildProperties.store(environmentBuildPropertiesFile);
 
 			System.out.println("Writing " + environmentBuildPropertiesFile);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7759
https://liferay.atlassian.net/browse/LRCI-7786

## What Is Being Fixed

The environment build properties parser only recognized Jenkins-hosted
environments (AWS and DB) and had no way to generate or load build properties
when running outside of Jenkins. It also could not inject secrets into the
generated property values when producing values for cloud mirrors.

## How It Is Being Fixed

A new LOCAL environment is selected whenever JENKINS_URL is unset or invalid,
and AWS becomes the fallback environment otherwise. Network-name detection is
updated to the current cloud-network and nuc-network names. When the resolved
environment is LOCAL, a sibling "-local" properties file is loaded and merged
onto the base properties. When generating property values for any non-local
environment, each value is resolved through SecretsUtil so secrets are injected
for the cloud mirrors.

## Why Are There No Tests?

The changes are to the jenkins-results-parser CI tooling, whose environment
detection and property generation are exercised only in the live Jenkins and
local runtime environments. There is no unit-test harness for this code path.

## PR Check

**pr-check: PASS** — tested on `f52d26d1d8209fa8f8ddd3f79af02e19ec3f694e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "f52d26d1d8209fa8f8ddd3f79af02e19ec3f694e"} -->
